### PR TITLE
feat: setting `options.path` to null respond on every path

### DIFF
--- a/.changeset/little-tools-ask.md
+++ b/.changeset/little-tools-ask.md
@@ -1,0 +1,6 @@
+---
+'@tmcp/transport-http': minor
+'@tmcp/transport-sse': minor
+---
+
+feat: setting `options.path` to null respond on every path

--- a/packages/transport-http/README.md
+++ b/packages/transport-http/README.md
@@ -72,13 +72,16 @@ httpServer.listen(3000, () => {
 
 ```javascript
 const transport = new HttpTransport(server, {
-	// Custom MCP endpoint path (default: '/mcp')
+	// Custom MCP endpoint path (default: '/mcp', use null to respond on every path)
 	path: '/api/mcp',
 	// Custom session ID generation
 	getSessionId: () => {
 		return `session-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 	},
 });
+
+> [!NOTE]
+> When the transport runs in development mode and you omit the `path` option, a warning is emitted. Future releases will treat an `undefined` path as "respond on every path", so set the property explicitly (for example `path: '/mcp'` or `path: null`) to lock in the behavior you want today.
 ```
 
 ### With Custom Context
@@ -162,7 +165,7 @@ const transport = new HttpTransport(server, {
 - **🌐 HTTP/SSE Communication**: Uses Server-Sent Events for real-time bidirectional communication
 - **🔄 Session Management**: Maintains client sessions with automatic session ID generation
 - **📡 Streaming Responses**: Supports streaming responses through SSE
-- **🛤️ Configurable Path**: Customizable MCP endpoint path with automatic filtering
+- **🛤️ Configurable Path**: Customizable MCP endpoint path with automatic filtering (set `path` to `null` to respond everywhere)
 - **🔧 Framework Agnostic**: Works with any HTTP server framework (Fastify, Bun, Deno, etc.)
 - **⚡ Real-time Updates**: Server can push notifications and updates to connected clients
 - **🛡️ Error Handling**: Graceful error handling for malformed requests
@@ -190,7 +193,7 @@ Creates a new HTTP transport instance.
 ```typescript
 interface HttpTransportOptions {
 	getSessionId: () => string; // Custom session ID generator
-	path?: string; // MCP endpoint path (default: '/mcp')
+	path?: string | null; // MCP endpoint path (default: '/mcp', null responds on every path)
 	oauth?: OAuth; // an oauth provider generated from @tmcp/auth
 	sessionManager?: SessionManager; // Custom session manager (default: InMemorySessionManager)
 }

--- a/packages/transport-http/package.json
+++ b/packages/transport-http/package.json
@@ -34,7 +34,8 @@
 		"directory": "packages/transport-http"
 	},
 	"dependencies": {
-		"@tmcp/session-manager": "workspace:^"
+		"@tmcp/session-manager": "workspace:^",
+		"esm-env": "^1.2.2"
 	},
 	"devDependencies": {
 		"@modelcontextprotocol/sdk": "^1.17.1",

--- a/packages/transport-sse/README.md
+++ b/packages/transport-sse/README.md
@@ -71,7 +71,7 @@ httpServer.listen(3000, () => {
 
 ```javascript
 const transport = new SseTransport(server, {
-	// Custom SSE endpoint path (default: '/sse')
+	// Custom SSE endpoint path (default: '/sse', use null to respond on every path)
 	path: '/api/events',
 	// Custom message endpoint path (default: '/message')
 	endpoint: '/api/message',
@@ -81,6 +81,9 @@ const transport = new SseTransport(server, {
 	},
 	oauth: OAuth; // an oauth provider generated from @tmcp/auth
 });
+
+> [!NOTE]
+> In development you'll see a warning when the `path` option is omitted. Upcoming releases will interpret an `undefined` path as "respond on every path", so set the field explicitly (for example `path: '/sse'` or `path: null`) to keep the behaviour you expect.
 ```
 
 ### With Custom Context
@@ -184,7 +187,7 @@ Creates a new SSE transport instance.
 ```typescript
 interface SseTransportOptions {
 	getSessionId?: () => string; // Custom session ID generator
-	path?: string; // SSE endpoint path (default: '/sse')
+	path?: string | null; // SSE endpoint path (default: '/sse', null responds on every path)
 	endpoint?: string; // Message endpoint path (default: '/message')
 	oauth?: OAuth; // an oauth provider generated from @tmcp/auth
 	sessionManager?: SessionManager; // Custom session manager (default: InMemorySessionManager)

--- a/packages/transport-sse/package.json
+++ b/packages/transport-sse/package.json
@@ -31,7 +31,8 @@
 		"directory": "packages/transport-sse"
 	},
 	"dependencies": {
-		"@tmcp/session-manager": "workspace:^"
+		"@tmcp/session-manager": "workspace:^",
+		"esm-env": "^1.2.2"
 	},
 	"devDependencies": {
 		"@tmcp/auth": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       '@tmcp/session-manager':
         specifier: workspace:^
         version: link:../session-manager
+      esm-env:
+        specifier: ^1.2.2
+        version: 1.2.2
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.17.1
@@ -371,6 +374,9 @@ importers:
       '@tmcp/session-manager':
         specifier: workspace:^
         version: link:../session-manager
+      esm-env:
+        specifier: ^1.2.2
+        version: 1.2.2
     devDependencies:
       '@tmcp/auth':
         specifier: workspace:^
@@ -1732,6 +1738,9 @@ packages:
     peerDependenciesMeta:
       jiti:
         optional: true
+
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
@@ -4275,6 +4284,8 @@ snapshots:
       optionator: 0.9.4
     transitivePeerDependencies:
       - supports-color
+
+  esm-env@1.2.2: {}
 
   espree@10.4.0:
     dependencies:


### PR DESCRIPTION
This adds the ability to pass `null` to `path` to allow the transport to respond to every request...this is useful if you already have a router and are invoking the transport from a single path because it means you don't have to keep them in sync. It also allows the same MCP server to be hosted from different paths (in case you need that for some reasons).

Right now it only works with `null` but I plan to do the same for `undefined` in the next major, so I've also added a warning in dev for people using this behaviour right now.