### PR TITLE
feat: cli transport

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -15,6 +15,7 @@
 	"dependencies": {
 		"@tmcp/adapter-valibot": "workspace:^",
 		"@tmcp/transport-stdio": "workspace:^",
+		"@tmcp/transport-cli": "workspace:^",
 		"tmcp": "workspace:^",
 		"valibot": "^1.1.0",
 		"zod": "^4.2.0"

--- a/apps/playground/src/cli.ts
+++ b/apps/playground/src/cli.ts
@@ -1,0 +1,8 @@
+#! /bin/env node
+
+import { CliTransport } from '@tmcp/transport-cli';
+import { server } from './index.ts';
+
+const cli = new CliTransport(server);
+
+await cli.run();

--- a/apps/playground/src/index.ts
+++ b/apps/playground/src/index.ts
@@ -11,7 +11,7 @@ import * as v from 'valibot';
 import * as z from 'zod';
 import { defineResource } from 'tmcp/resource';
 
-const server = new McpServer(
+export const server = new McpServer(
 	{
 		name: 'playground',
 		version: '1.0.0',

--- a/apps/playground/tsconfig.json
+++ b/apps/playground/tsconfig.json
@@ -1,10 +1,12 @@
 {
 	"compilerOptions": {
 		"target": "ES2022",
-		"module": "nodenext",
-		"moduleResolution": "nodenext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"noEmit": true,
 		"esModuleInterop": true,
 		"allowSyntheticDefaultImports": true,
+		"allowImportingTsExtensions": true,
 		"strict": true,
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,

--- a/packages/transport-cli/LICENSE
+++ b/packages/transport-cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Paolo Ricciuti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/transport-cli/README.md
+++ b/packages/transport-cli/README.md
@@ -1,0 +1,136 @@
+# @tmcp/transport-cli
+
+A CLI transport for TMCP that turns your MCP server's tools into command-line commands. Each registered tool becomes a subcommand with flags derived from its JSON Schema input, powered by [yargs](https://yargs.js.org/).
+
+## Installation
+
+```bash
+pnpm add @tmcp/transport-cli tmcp
+```
+
+## Usage
+
+```javascript
+import { McpServer } from 'tmcp';
+import { CliTransport } from '@tmcp/transport-cli';
+import { ZodJsonSchemaAdapter } from '@tmcp/adapter-zod';
+import { z } from 'zod';
+
+const server = new McpServer(
+	{
+		name: 'my-cli',
+		version: '1.0.0',
+		description: 'My CLI tool',
+	},
+	{
+		adapter: new ZodJsonSchemaAdapter(),
+		capabilities: { tools: {} },
+	},
+);
+
+server.tool(
+	{
+		name: 'greet',
+		description: 'Greet someone by name',
+		schema: z.object({
+			name: z.string().describe('Name of the person to greet'),
+			loud: z.boolean().optional().describe('Shout the greeting'),
+		}),
+	},
+	async (input) => {
+		const text = `Hello, ${input.name}!`;
+		return {
+			content: [
+				{ type: 'text', text: input.loud ? text.toUpperCase() : text },
+			],
+		};
+	},
+);
+
+const cli = new CliTransport(server);
+await cli.run(undefined, process.argv.slice(2));
+```
+
+Running the above:
+
+```bash
+node my-cli.js greet --name Alice
+# {"content":[{"type":"text","text":"Hello, Alice!"}]}
+
+node my-cli.js greet --name Alice --loud
+# {"content":[{"type":"text","text":"HELLO, ALICE!"}]}
+```
+
+Output is pretty-printed JSON written to stdout. Errors go to stderr and set `process.exitCode` to 1.
+
+The help output uses the server's `name` (from the `McpServer` config) as the CLI program name. In the example above, `--help` would show `my-cli` as the command name.
+
+## Argument types
+
+The transport maps JSON Schema types from your tool's input schema to yargs option types:
+
+| JSON Schema type | yargs type | Example                      |
+| ---------------- | ---------- | ---------------------------- |
+| `string`         | `string`   | `--name Alice`               |
+| `number`         | `number`   | `--count 5`                  |
+| `integer`        | `number`   | `--port 8080`                |
+| `boolean`        | `boolean`  | `--verbose` / `--no-verbose` |
+| `array`          | `array`    | `--items foo --items bar`    |
+
+Properties marked as required in the schema are enforced by yargs (`demandOption`). Optional properties can be omitted. Enum values (e.g. from `z.enum()` or `v.picklist()`) are passed through as `choices`.
+
+## Custom context
+
+If your server uses custom context, you can pass it as the first argument to `run()`:
+
+```javascript
+const cli = new CliTransport(server);
+await cli.run({ userId: 'cli-user' }, process.argv.slice(2));
+```
+
+The context is forwarded to the server on every request, so your tool handlers can read it from `server.ctx.custom`.
+
+## API
+
+### `CliTransport`
+
+#### Constructor
+
+```typescript
+new CliTransport(server: McpServer)
+```
+
+Creates a new CLI transport. The `server` parameter is the TMCP server instance whose tools will be exposed as commands.
+
+#### Methods
+
+##### `run(ctx?: TCustom, argv?: string[]): Promise<void>`
+
+Initializes an MCP session, fetches the tool list from the server, builds yargs commands from the tool definitions, and parses the given argv (or `process.argv.slice(2)` if omitted).
+
+- `ctx` - Optional custom context passed to the server for this invocation.
+- `argv` - Optional array of CLI arguments. Defaults to `process.argv.slice(2)`.
+
+## How it works
+
+1. The transport sends an `initialize` JSON-RPC request to the server to start a session.
+2. It calls `tools/list` to get all registered tools and their input schemas.
+3. For each tool, it registers a yargs command using the tool name and converts the tool's `inputSchema` properties into yargs options.
+4. When the user invokes a command, the parsed arguments are coerced back to their schema types and sent as a `tools/call` request.
+5. The result is written to stdout as pretty-printed JSON.
+
+## Related Packages
+
+- [`tmcp`](../tmcp) - Core TMCP server implementation
+- [`@tmcp/transport-stdio`](../transport-stdio) - Standard I/O transport
+- [`@tmcp/transport-http`](../transport-http) - HTTP transport
+- [`@tmcp/adapter-zod`](../adapter-zod) - Zod schema adapter
+- [`@tmcp/adapter-valibot`](../adapter-valibot) - Valibot schema adapter
+
+## Acknowledgments
+
+Huge thanks to Sean O'Bannon that provided us with the `@tmcp` scope on npm.
+
+## License
+
+MIT

--- a/packages/transport-cli/README.md
+++ b/packages/transport-cli/README.md
@@ -1,6 +1,6 @@
 # @tmcp/transport-cli
 
-A CLI transport for TMCP that turns your MCP server's tools into command-line commands. Each registered tool becomes a subcommand with flags derived from its JSON Schema input, powered by [yargs](https://yargs.js.org/).
+A CLI transport for TMCP that exposes your MCP tools as static, JSON-first commands. It is designed for agent-driven usage: tools are invoked with JSON input, schemas can be inspected directly, and output can be narrowed before it leaves stdout.
 
 ## Installation
 
@@ -33,16 +33,24 @@ server.tool(
 		name: 'greet',
 		description: 'Greet someone by name',
 		schema: z.object({
-			name: z.string().describe('Name of the person to greet'),
-			loud: z.boolean().optional().describe('Shout the greeting'),
+			name: z.string(),
+			loud: z.boolean().optional(),
+		}),
+		outputSchema: z.object({
+			message: z.string(),
 		}),
 	},
 	async (input) => {
-		const text = `Hello, ${input.name}!`;
+		const message = `Hello, ${input.name}!`;
+
 		return {
 			content: [
-				{ type: 'text', text: input.loud ? text.toUpperCase() : text },
+				{
+					type: 'text',
+					text: input.loud ? message.toUpperCase() : message,
+				},
 			],
+			structuredContent: { message },
 		};
 	},
 );
@@ -51,44 +59,83 @@ const cli = new CliTransport(server);
 await cli.run(undefined, process.argv.slice(2));
 ```
 
-Running the above:
+## Commands
+
+### `tools`
+
+Prints the available tools as pretty JSON.
 
 ```bash
-node my-cli.js greet --name Alice
-# {"content":[{"type":"text","text":"Hello, Alice!"}]}
-
-node my-cli.js greet --name Alice --loud
-# {"content":[{"type":"text","text":"HELLO, ALICE!"}]}
+node my-cli.js tools
 ```
 
-Output is pretty-printed JSON written to stdout. Errors go to stderr and set `process.exitCode` to 1.
+### `schema <tool>`
 
-The help output uses the server's `name` (from the `McpServer` config) as the CLI program name. In the example above, `--help` would show `my-cli` as the command name.
+Prints the tool metadata plus its input and output schemas.
 
-## Argument types
+```bash
+node my-cli.js schema greet
+```
 
-The transport maps JSON Schema types from your tool's input schema to yargs option types:
+### `call <tool> [input]`
 
-| JSON Schema type | yargs type | Example                      |
-| ---------------- | ---------- | ---------------------------- |
-| `string`         | `string`   | `--name Alice`               |
-| `number`         | `number`   | `--count 5`                  |
-| `integer`        | `number`   | `--port 8080`                |
-| `boolean`        | `boolean`  | `--verbose` / `--no-verbose` |
-| `array`          | `array`    | `--items foo --items bar`    |
+Calls a tool with a JSON object. The first positional argument is the primary input source.
 
-Properties marked as required in the schema are enforced by yargs (`demandOption`). Optional properties can be omitted. Enum values (e.g. from `z.enum()` or `v.picklist()`) are passed through as `choices`.
+```bash
+node my-cli.js call greet '{"name":"Alice"}'
+```
+
+### `<tool> [input]`
+
+Each tool name is also registered directly as an alias for `call <tool>`, unless the tool name would collide with a reserved command (`tools`, `schema`, or `call`).
+
+```bash
+node my-cli.js greet '{"name":"Alice","loud":true}'
+```
+
+## Input sources
+
+Tool calls accept exactly one input source:
+
+- Positional JSON: `greet '{"name":"Alice"}'`
+
+All inputs must parse to a JSON object. If no input is provided, the transport sends `{}`.
+
+## Output controls
+
+Tool calls support two static output flags:
+
+- `--output full|structured|content|text`
+- `--fields path1,path2`
+
+Examples:
+
+```bash
+node my-cli.js greet '{"name":"Alice"}' --output text
+
+node my-cli.js get-user '{"id":"1"}' --output structured --fields user.name,user.email
+```
+
+`--fields` uses comma-separated dot paths and is applied after the output mode is selected. It is not available with `--output text`.
+
+## Behavior
+
+- Output is written to stdout.
+- JSON outputs are pretty-printed.
+- Errors are written to stderr and set `process.exitCode` to `1`.
+- The CLI initializes an MCP session, sends `notifications/initialized`, and paginates through `tools/list` automatically.
+- The program name shown in help output comes from `McpServer`'s `name`.
 
 ## Custom context
 
-If your server uses custom context, you can pass it as the first argument to `run()`:
+If your server uses custom context, pass it as the first argument to `run()`:
 
 ```javascript
 const cli = new CliTransport(server);
 await cli.run({ userId: 'cli-user' }, process.argv.slice(2));
 ```
 
-The context is forwarded to the server on every request, so your tool handlers can read it from `server.ctx.custom`.
+The context is forwarded on every request, so handlers can read it from `server.ctx.custom`.
 
 ## API
 
@@ -100,24 +147,13 @@ The context is forwarded to the server on every request, so your tool handlers c
 new CliTransport(server: McpServer)
 ```
 
-Creates a new CLI transport. The `server` parameter is the TMCP server instance whose tools will be exposed as commands.
-
 #### Methods
 
-##### `run(ctx?: TCustom, argv?: string[]): Promise<void>`
+```typescript
+run(ctx?: TCustom, argv?: string[]): Promise<void>
+```
 
-Initializes an MCP session, fetches the tool list from the server, builds yargs commands from the tool definitions, and parses the given argv (or `process.argv.slice(2)` if omitted).
-
-- `ctx` - Optional custom context passed to the server for this invocation.
-- `argv` - Optional array of CLI arguments. Defaults to `process.argv.slice(2)`.
-
-## How it works
-
-1. The transport sends an `initialize` JSON-RPC request to the server to start a session.
-2. It calls `tools/list` to get all registered tools and their input schemas.
-3. For each tool, it registers a yargs command using the tool name and converts the tool's `inputSchema` properties into yargs options.
-4. When the user invokes a command, the parsed arguments are coerced back to their schema types and sent as a `tools/call` request.
-5. The result is written to stdout as pretty-printed JSON.
+Starts the CLI, initializes a session, discovers tools, and executes the requested static command or tool alias.
 
 ## Related Packages
 

--- a/packages/transport-cli/README.md
+++ b/packages/transport-cli/README.md
@@ -138,6 +138,27 @@ await cli.run({ userId: 'cli-user' }, process.argv.slice(2));
 
 The context is forwarded on every request, so handlers can read it from `server.ctx.custom`.
 
+## Extending the CLI
+
+Pass a `setup` callback to the constructor to customize the underlying [`sade`](https://github.com/lukeed/sade) instance. The hook runs after the built-in commands (`tools`, `schema`, `call`) and tool aliases have been registered, but before arguments are parsed, so you can add new commands, set a version, examples, and more.
+
+```javascript
+const cli = new CliTransport(server, {
+	setup: (prog) => {
+		prog
+			.version('1.2.3')
+			.command('hello <name>', 'Say hi')
+			.action((name) => {
+				console.log(`Hello, ${name}!`);
+			});
+	},
+});
+
+await cli.run();
+```
+
+Custom command actions are awaited, so async handlers work as expected. Custom command names must not collide with built-in commands (`tools`, `schema`, `call`) or tool aliases — sade will throw `Command already exists` if they do.
+
 ## API
 
 ### `CliTransport`
@@ -145,7 +166,7 @@ The context is forwarded on every request, so handlers can read it from `server.
 #### Constructor
 
 ```typescript
-new CliTransport(server: McpServer)
+new CliTransport(server: McpServer, options?: { setup?: (prog: Sade) => void })
 ```
 
 #### Methods

--- a/packages/transport-cli/README.md
+++ b/packages/transport-cli/README.md
@@ -123,6 +123,7 @@ node my-cli.js get-user '{"id":"1"}' --output structured --fields user.name,user
 - Output is written to stdout.
 - JSON outputs are pretty-printed.
 - Errors are written to stderr and set `process.exitCode` to `1`.
+- Running the CLI without a command prints help output.
 - The CLI initializes an MCP session, sends `notifications/initialized`, and paginates through `tools/list` automatically.
 - The program name shown in help output comes from `McpServer`'s `name`.
 

--- a/packages/transport-cli/package.json
+++ b/packages/transport-cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@tmcp/transport-cli",
 	"version": "0.0.1",
-	"description": "CLI transport for TMCP - exposes MCP tools as CLI commands via yargs",
+	"description": "CLI transport for TMCP - exposes MCP tools as CLI commands via sade",
 	"type": "module",
 	"main": "src/index.js",
 	"types": "src/types/index.d.ts",
@@ -24,13 +24,13 @@
 		"tmcp": "^1.16.3"
 	},
 	"dependencies": {
-		"yargs": "^17.7.2"
+		"sade": "^1.8.1"
 	},
 	"keywords": [
 		"tmcp",
 		"cli",
 		"transport",
-		"yargs"
+		"sade"
 	],
 	"repository": {
 		"type": "git",
@@ -40,7 +40,6 @@
 	"devDependencies": {
 		"@tmcp/adapter-valibot": "workspace:^",
 		"@types/node": "^24.0.13",
-		"@types/yargs": "^17.0.33",
 		"dts-buddy": "^0.6.2",
 		"publint": "^0.3.12",
 		"tmcp": "workspace:^",

--- a/packages/transport-cli/package.json
+++ b/packages/transport-cli/package.json
@@ -5,6 +5,9 @@
 	"type": "module",
 	"main": "src/index.js",
 	"types": "src/types/index.d.ts",
+	"engines": {
+		"node": ">=18.0.0"
+	},
 	"scripts": {
 		"generate:types": "dts-buddy && publint",
 		"prepublish": "pnpm generate:types",

--- a/packages/transport-cli/package.json
+++ b/packages/transport-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tmcp/transport-cli",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"description": "CLI transport for TMCP with static JSON-first tool commands",
 	"type": "module",
 	"main": "src/index.js",

--- a/packages/transport-cli/package.json
+++ b/packages/transport-cli/package.json
@@ -10,6 +10,9 @@
 		"prepublish": "pnpm generate:types",
 		"test": "vitest"
 	},
+	"files": [
+		"src"
+	],
 	"exports": {
 		".": {
 			"types": "./src/types/index.d.ts",

--- a/packages/transport-cli/package.json
+++ b/packages/transport-cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@tmcp/transport-cli",
-	"version": "0.0.1",
-	"description": "CLI transport for TMCP - exposes MCP tools as CLI commands via sade",
+	"version": "0.0.2",
+	"description": "CLI transport for TMCP with static JSON-first tool commands",
 	"type": "module",
 	"main": "src/index.js",
 	"types": "src/types/index.d.ts",
@@ -30,7 +30,8 @@
 		"tmcp",
 		"cli",
 		"transport",
-		"sade"
+		"mcp",
+		"json"
 	],
 	"repository": {
 		"type": "git",

--- a/packages/transport-cli/package.json
+++ b/packages/transport-cli/package.json
@@ -1,0 +1,50 @@
+{
+	"name": "@tmcp/transport-cli",
+	"version": "0.0.1",
+	"description": "CLI transport for TMCP - exposes MCP tools as CLI commands via yargs",
+	"type": "module",
+	"main": "src/index.js",
+	"types": "src/types/index.d.ts",
+	"scripts": {
+		"generate:types": "dts-buddy && publint",
+		"prepublish": "pnpm generate:types",
+		"test": "vitest"
+	},
+	"exports": {
+		".": {
+			"types": "./src/types/index.d.ts",
+			"default": "./src/index.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"peerDependencies": {
+		"tmcp": "^1.16.3"
+	},
+	"dependencies": {
+		"yargs": "^17.7.2"
+	},
+	"keywords": [
+		"tmcp",
+		"cli",
+		"transport",
+		"yargs"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/paoloricciuti/tmcp.git",
+		"directory": "packages/transport-cli"
+	},
+	"devDependencies": {
+		"@tmcp/adapter-valibot": "workspace:^",
+		"@types/node": "^24.0.13",
+		"@types/yargs": "^17.0.33",
+		"dts-buddy": "^0.6.2",
+		"publint": "^0.3.12",
+		"tmcp": "workspace:^",
+		"valibot": "^1.1.0",
+		"vitest": "^4.0.6"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/transport-cli/package.json
+++ b/packages/transport-cli/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"main": "src/index.js",
 	"types": "src/types/index.d.ts",
+	"license": "MIT",
 	"engines": {
 		"node": ">=18.0.0"
 	},

--- a/packages/transport-cli/src/index.js
+++ b/packages/transport-cli/src/index.js
@@ -20,6 +20,7 @@ const CLIENT_INFO = {
 };
 
 const RESERVED_COMMANDS = new Set(['call', 'schema', 'tools']);
+const UNSAFE_ALIAS_NAME = /[<>[\]]/;
 
 /**
  * @param {unknown} value
@@ -481,39 +482,25 @@ export class CliTransport {
 	 * @param {Array<string>} [argv]
 	 */
 	async run(ctx, argv) {
-		const init_result = await this.#initialize(ctx);
-		const tools = await this.#list_tools(ctx);
-		const script_name = init_result?.serverInfo?.name ?? 'tmcp';
-		const prog = sade(script_name);
+		try {
+			const init_result = await this.#initialize(ctx);
+			const tools = await this.#list_tools(ctx);
+			const script_name = init_result?.serverInfo?.name ?? 'tmcp';
+			const prog = sade(script_name);
 
-		/** @type {Map<string, Tool>} */
-		const tool_map = new Map();
+			/** @type {Map<string, Tool>} */
+			const tool_map = new Map();
 
-		for (const tool of tools) {
-			tool_map.set(tool.name, tool);
-		}
+			for (const tool of tools) {
+				tool_map.set(tool.name, tool);
+			}
 
-		prog.command('tools', 'List available tools').action(() => {});
-		prog.command('schema <tool>', 'Print a tool schema').action(() => {});
-
-		const call_command = prog
-			.command('call <tool> [input]', 'Call a tool with JSON input')
-			.option(
-				'--output',
-				'Select full, structured, content, or text output',
-				'full',
-			)
-			.option(
-				'--fields',
-				'Select comma-separated dot paths from the chosen output',
+			prog.command('tools', 'List available tools').action(() => {});
+			prog.command('schema <tool>', 'Print a tool schema').action(
+				() => {},
 			);
 
-		call_command.action(() => {});
-
-		for (const tool of tools) {
-			if (RESERVED_COMMANDS.has(tool.name)) continue;
-
-			prog.command(`${tool.name} [input]`, tool.description ?? '')
+			prog.command('call <tool> [input]', 'Call a tool with JSON input')
 				.option(
 					'--output',
 					'Select full, structured, content, or text output',
@@ -524,17 +511,40 @@ export class CliTransport {
 					'Select comma-separated dot paths from the chosen output',
 				)
 				.action(() => {});
-		}
 
-		const args = argv ? ['node', script_name, ...argv] : process.argv;
-		const parsed = prog.parse(args, { lazy: true });
+			for (const tool of tools) {
+				if (RESERVED_COMMANDS.has(tool.name)) {
+					continue;
+				}
 
-		if (!parsed) return;
+				if (UNSAFE_ALIAS_NAME.test(tool.name)) {
+					process.stderr.write(
+						`Warning: skipping bare alias for tool "${tool.name}" because its name contains CLI syntax characters. Use \`call ${tool.name}\` instead.\n`,
+					);
+					continue;
+				}
 
-		const { name, args: handler_args } = parsed;
-		const { positionals, options } = extract_command_args(handler_args);
+				prog.command(`${tool.name} [input]`, tool.description ?? '')
+					.option(
+						'--output',
+						'Select full, structured, content, or text output',
+						'full',
+					)
+					.option(
+						'--fields',
+						'Select comma-separated dot paths from the chosen output',
+					)
+					.action(() => {});
+			}
 
-		try {
+			const args = argv ? ['node', script_name, ...argv] : process.argv;
+			const parsed = prog.parse(args, { lazy: true });
+
+			if (!parsed) return;
+
+			const { name, args: handler_args } = parsed;
+			const { positionals, options } = extract_command_args(handler_args);
+
 			if (name === 'tools') {
 				process.stdout.write(format_json(tools));
 				return;

--- a/packages/transport-cli/src/index.js
+++ b/packages/transport-cli/src/index.js
@@ -3,6 +3,7 @@
  * @import { ListToolsResult, Tool } from "./internal.js";
  */
 import process from 'node:process';
+import { randomUUID } from 'node:crypto';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import sade from 'sade';
 
@@ -234,7 +235,11 @@ function filter_fields(value, paths) {
 		if (segments.length === 0) {
 			throw new Error('`--fields` only supports dot-separated paths');
 		}
-		set_path_value(result, segments, get_path_value(value, segments));
+		set_path_value(
+			result,
+			segments,
+			structuredClone(get_path_value(value, segments)),
+		);
 	}
 
 	return result;
@@ -324,7 +329,7 @@ export class CliTransport {
 	/**
 	 * @type {string}
 	 */
-	#session_id = crypto.randomUUID();
+	#session_id = randomUUID();
 
 	/**
 	 * @param {McpServer<any, TCustom>} server

--- a/packages/transport-cli/src/index.js
+++ b/packages/transport-cli/src/index.js
@@ -21,7 +21,7 @@ const CLIENT_INFO = {
 };
 
 const RESERVED_COMMANDS = new Set(['call', 'schema', 'tools']);
-const UNSAFE_ALIAS_NAME = /[<>[\]]/;
+const UNSAFE_ALIAS_NAME = /[<>[\]\s]/;
 
 /**
  * @param {unknown} value

--- a/packages/transport-cli/src/index.js
+++ b/packages/transport-cli/src/index.js
@@ -308,6 +308,36 @@ function format_tool_result(result, options) {
 }
 
 /**
+ * @param {Record<string, unknown>} result
+ * @returns {string}
+ */
+function format_tool_error(result) {
+	const content = result.content;
+
+	if (Array.isArray(content)) {
+		const text_blocks = content
+			.map((item) => {
+				if (
+					is_record(item) &&
+					item.type === 'text' &&
+					typeof item.text === 'string'
+				) {
+					return item.text;
+				}
+
+				return undefined;
+			})
+			.filter((item) => typeof item === 'string');
+
+		if (text_blocks.length > 0) {
+			return text_blocks.join('\n');
+		}
+	}
+
+	return JSON.stringify(result, null, 2);
+}
+
+/**
  * @template {Record<string, unknown> | undefined} [TCustom=undefined]
  */
 export class CliTransport {
@@ -478,6 +508,12 @@ export class CliTransport {
 		const tool = this.#get_tool(tool_map, name);
 		const args = await resolve_tool_input(input);
 		const result = await this.#call_tool(tool.name, args, ctx);
+
+		if (result?.isError) {
+			process.stderr.write(`Error: ${format_tool_error(result)}\n`);
+			process.exitCode = 1;
+			return;
+		}
 
 		process.stdout.write(format_tool_result(result, options));
 	}

--- a/packages/transport-cli/src/index.js
+++ b/packages/transport-cli/src/index.js
@@ -1,0 +1,277 @@
+/**
+ * @import { McpServer } from "tmcp";
+ * @import { Options } from "yargs";
+ * @import { InputSchema, Tool } from "./internal.js";
+ */
+import process from 'node:process';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import Yargs from 'yargs/yargs';
+
+/**
+ * Maps a JSON Schema type string to a yargs option type.
+ * @param {string | undefined} json_schema_type
+ * @returns {Options["type"]}
+ */
+function json_schema_type_to_yargs(json_schema_type) {
+	switch (json_schema_type) {
+		case 'string':
+			return 'string';
+		case 'number':
+		case 'integer':
+			return 'number';
+		case 'boolean':
+			return 'boolean';
+		case 'array':
+			return 'array';
+		default:
+			return 'string';
+	}
+}
+
+/**
+ * Converts a JSON Schema inputSchema into a yargs options object.
+ * @param {InputSchema} input_schema
+ * @returns {Record<string, Options>}
+ */
+function json_schema_to_yargs_options(input_schema) {
+	/** @type {Record<string, Options>} */
+	const options = {};
+
+	const properties = input_schema.properties ?? {};
+	const required = new Set(input_schema.required ?? []);
+
+	for (const [name, schema] of Object.entries(properties)) {
+		/** @type {Options} */
+		const option = {};
+
+		option.type = json_schema_type_to_yargs(schema.type);
+		option.demandOption = required.has(name);
+
+		if (schema.description) {
+			option.describe = schema.description;
+		}
+
+		if (schema.enum) {
+			option.choices =
+				/** @type {Array<string | number | true | undefined>} */ (
+					schema.enum
+				);
+		}
+
+		if (schema.default !== undefined) {
+			option.default = schema.default;
+		}
+
+		options[name] = option;
+	}
+
+	return options;
+}
+
+/**
+ * Coerces parsed yargs arguments back to their JSON Schema types.
+ * Yargs parses everything from argv as strings by default for some types,
+ * so we need to coerce values based on the schema.
+ * @param {Record<string, unknown>} args
+ * @param {InputSchema} input_schema
+ * @returns {Record<string, unknown>}
+ */
+function coerce_args(args, input_schema) {
+	/** @type {Record<string, unknown>} */
+	const result = {};
+	const properties = input_schema.properties ?? {};
+
+	for (const [key, schema] of Object.entries(properties)) {
+		const value = args[key];
+
+		if (value === undefined) continue;
+
+		if (schema?.type === 'integer' && typeof value === 'string') {
+			result[key] = parseInt(value, 10);
+		} else if (schema?.type === 'number' && typeof value === 'string') {
+			result[key] = parseFloat(value);
+		} else if (schema?.type === 'object' && typeof value === 'string') {
+			try {
+				result[key] = JSON.parse(value);
+			} catch {
+				result[key] = value;
+			}
+		} else {
+			result[key] = value;
+		}
+	}
+
+	return result;
+}
+
+/**
+ * @template {Record<string, unknown> | undefined} [TCustom=undefined]
+ */
+export class CliTransport {
+	/**
+	 * @type {McpServer<any, TCustom>}
+	 */
+	#server;
+
+	/**
+	 * @type {AsyncLocalStorage<string | undefined>}
+	 */
+	#session_id_storage = new AsyncLocalStorage();
+
+	/**
+	 * @type {number}
+	 */
+	#request_id = 0;
+
+	/**
+	 * @type {string}
+	 */
+	#session_id = crypto.randomUUID();
+
+	/**
+	 * @param {McpServer<any, TCustom>} server
+	 */
+	constructor(server) {
+		this.#server = server;
+	}
+
+	/**
+	 * Sends a JSON-RPC request to the server and returns the result.
+	 * @param {string} method
+	 * @param {Record<string, unknown>} [params]
+	 * @param {TCustom} [ctx]
+	 * @returns {Promise<any>}
+	 */
+	async #request(method, params, ctx) {
+		const request_id = this.#request_id++;
+
+		const response = await this.#session_id_storage.run(
+			this.#session_id,
+			() =>
+				this.#server.receive(
+					{
+						jsonrpc: '2.0',
+						id: request_id,
+						method,
+						...(params ? { params } : {}),
+					},
+					{
+						sessionId: this.#session_id,
+						custom: ctx,
+					},
+				),
+		);
+
+		if (response?.error) {
+			throw new Error(response.error.message ?? 'Unknown JSON-RPC error');
+		}
+
+		return response?.result;
+	}
+
+	/**
+	 * Initialize the MCP session with the server.
+	 * @param {TCustom} [ctx]
+	 * @returns {Promise<{ serverInfo?: { name?: string } }>}
+	 */
+	async #initialize(ctx) {
+		return this.#request(
+			'initialize',
+			{
+				protocolVersion: '2025-03-26',
+				capabilities: {},
+				clientInfo: {
+					name: 'tmcp-cli',
+					version: '0.0.1',
+				},
+			},
+			ctx,
+		);
+	}
+
+	/**
+	 * Fetches the list of tools from the server.
+	 * @param {TCustom} [ctx]
+	 * @returns {Promise<Array<Tool>>}
+	 */
+	async #list_tools(ctx) {
+		const result = await this.#request('tools/list', undefined, ctx);
+		return result?.tools ?? [];
+	}
+
+	/**
+	 * Calls a tool by name with arguments.
+	 * @param {string} name
+	 * @param {Record<string, unknown>} [args]
+	 * @param {TCustom} [ctx]
+	 * @returns {Promise<any>}
+	 */
+	async #call_tool(name, args, ctx) {
+		return this.#request(
+			'tools/call',
+			{
+				name,
+				arguments: args ?? {},
+			},
+			ctx,
+		);
+	}
+
+	/**
+	 * Starts the CLI. Initializes the MCP session, lists tools,
+	 * builds yargs commands from the tool definitions, and parses argv.
+	 * @param {TCustom} [ctx]
+	 * @param {Array<string>} [argv]
+	 */
+	async run(ctx, argv) {
+		const init_result = await this.#initialize(ctx);
+
+		const tools = await this.#list_tools(ctx);
+
+		const script_name = init_result?.serverInfo?.name ?? 'tmcp';
+
+		const cli = Yargs(argv ?? process.argv.slice(2))
+			.scriptName(script_name)
+			.strict()
+			.demandCommand(
+				1,
+				'You need to specify a tool command to run. Use --help to see available tools.',
+			)
+			.help();
+
+		for (const tool of tools) {
+			const options = json_schema_to_yargs_options(tool.inputSchema);
+
+			cli.command(
+				tool.name,
+				tool.description ?? '',
+				(yargs) => yargs.options(options),
+				async (args) => {
+					try {
+						const coerced = coerce_args(
+							/** @type {Record<string, unknown>} */ (args),
+							tool.inputSchema,
+						);
+
+						const result = await this.#call_tool(
+							tool.name,
+							coerced,
+							ctx,
+						);
+
+						process.stdout.write(
+							JSON.stringify(result, null, 2) + '\n',
+						);
+					} catch (err) {
+						process.stderr.write(
+							`Error: ${err instanceof Error ? err.message : String(err)}\n`,
+						);
+						process.exitCode = 1;
+					}
+				},
+			);
+		}
+
+		await cli.parseAsync();
+	}
+}

--- a/packages/transport-cli/src/index.js
+++ b/packages/transport-cli/src/index.js
@@ -555,6 +555,9 @@ export class CliTransport {
 
 			for (const tool of tools) {
 				if (RESERVED_COMMANDS.has(tool.name)) {
+					process.stderr.write(
+						`Warning: skipping bare alias for tool "${tool.name}" because its name conflicts with a built-in command. Use \`call ${tool.name}\` instead.\n`,
+					);
 					continue;
 				}
 

--- a/packages/transport-cli/src/index.js
+++ b/packages/transport-cli/src/index.js
@@ -1,120 +1,304 @@
 /**
  * @import { McpServer } from "tmcp";
- * @import { InputSchema, Tool } from "./internal.js";
+ * @import { ListToolsResult, Tool } from "./internal.js";
  */
 import process from 'node:process';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import sade from 'sade';
 
 /**
- * @typedef {number | string | boolean | null} SadeValue
+ * @typedef {'full' | 'structured' | 'content' | 'text'} OutputMode
  */
 
 /**
- * Builds sade option flags from a JSON Schema property name and schema.
- * @param {string} name
- * @param {{ type?: string; description?: string; enum?: Array<unknown>; default?: unknown }} schema
- * @param {boolean} required
- * @returns {{ flags: string; description: string; default_value: SadeValue | undefined }}
+ * @typedef {{ output?: OutputMode; fields?: string }} ToolOptions
  */
-function build_option(name, schema, required) {
-	const flags = `--${name}`;
 
-	let description = schema.description ?? '';
+const CLIENT_INFO = {
+	name: 'tmcp-cli',
+	version: '0.0.1',
+};
 
-	if (schema.enum) {
-		const choices = schema.enum.join(', ');
-		description += description
-			? ` (choices: ${choices})`
-			: `choices: ${choices}`;
+const RESERVED_COMMANDS = new Set(['call', 'schema', 'tools']);
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function is_record(value) {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} source
+ * @returns {Record<string, unknown>}
+ */
+function parse_input_json(value, source) {
+	let parsed;
+
+	try {
+		parsed = JSON.parse(String(value));
+	} catch {
+		throw new Error(`Invalid JSON in ${source}`);
 	}
 
-	if (required) {
-		description += description ? ' (required)' : 'required';
+	if (!is_record(parsed)) {
+		throw new Error(`Input from ${source} must be a JSON object`);
+	}
+
+	return parsed;
+}
+
+/**
+ * @param {Array<unknown>} args
+ * @returns {{ positionals: Array<unknown>; options: Record<string, unknown> }}
+ */
+function extract_command_args(args) {
+	const last_arg = args.at(-1);
+
+	if (is_record(last_arg)) {
+		return {
+			positionals: args.slice(0, -1),
+			options: last_arg,
+		};
 	}
 
 	return {
-		flags,
-		description,
-		default_value: /** @type {SadeValue | undefined} */ (schema.default),
+		positionals: args,
+		options: {},
 	};
 }
 
 /**
- * Coerces parsed arguments back to their JSON Schema types.
- * sade parses everything from argv as strings by default,
- * so we need to coerce values based on the schema.
- * @param {Record<string, unknown>} args
- * @param {InputSchema} input_schema
- * @returns {Record<string, unknown>}
+ * @param {Record<string, unknown>} options
+ * @returns {ToolOptions}
  */
-function coerce_args(args, input_schema) {
-	/** @type {Record<string, unknown>} */
-	const result = {};
-	const properties = input_schema.properties ?? {};
+function normalize_tool_options(options) {
+	return {
+		output:
+			typeof options.output === 'string'
+				? /** @type {OutputMode} */ (options.output)
+				: 'full',
+		fields: typeof options.fields === 'string' ? options.fields : undefined,
+	};
+}
 
-	for (const [key, schema] of Object.entries(properties)) {
-		const value = args[key];
+/**
+ * @param {string | undefined} input
+ * @returns {Promise<Record<string, unknown>>}
+ */
+async function resolve_tool_input(input) {
+	if (typeof input === 'string') {
+		return parse_input_json(input, 'positional input');
+	}
 
-		if (value === undefined) continue;
+	return {};
+}
 
-		if (schema?.type === 'integer' && typeof value === 'string') {
-			result[key] = parseInt(value, 10);
-		} else if (schema?.type === 'number' && typeof value === 'string') {
-			result[key] = parseFloat(value);
-		} else if (schema?.type === 'boolean' && typeof value === 'string') {
-			result[key] = value === 'true';
-		} else if (schema?.type === 'object' && typeof value === 'string') {
-			try {
-				result[key] = JSON.parse(value);
-			} catch {
-				result[key] = value;
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function format_json(value) {
+	return `${JSON.stringify(value === undefined ? null : value, null, 2)}\n`;
+}
+
+/**
+ * @param {string | undefined} fields
+ * @returns {Array<string>}
+ */
+function parse_fields(fields) {
+	if (!fields) return [];
+
+	const paths = fields
+		.split(',')
+		.map((field) => field.trim())
+		.filter(Boolean);
+
+	if (paths.length === 0) {
+		throw new Error('`--fields` must include at least one dot path');
+	}
+
+	return paths;
+}
+
+/**
+ * @param {string} path
+ * @returns {Array<string>}
+ */
+function split_path(path) {
+	return path.split('.').filter(Boolean);
+}
+
+/**
+ * @param {unknown} value
+ * @param {Array<string>} path
+ * @returns {unknown}
+ */
+function get_path_value(value, path) {
+	let current = value;
+
+	for (const segment of path) {
+		if (Array.isArray(current)) {
+			const index = Number(segment);
+			if (
+				!Number.isInteger(index) ||
+				index < 0 ||
+				index >= current.length
+			) {
+				throw new Error(`Unknown field path: ${path.join('.')}`);
 			}
-		} else if (schema?.type === 'array' && typeof value === 'string') {
-			try {
-				result[key] = JSON.parse(value);
-			} catch {
-				result[key] = value.split(',');
-			}
-		} else {
-			result[key] = value;
+			current = current[index];
+			continue;
 		}
+
+		if (!is_record(current) || !(segment in current)) {
+			throw new Error(`Unknown field path: ${path.join('.')}`);
+		}
+
+		current = current[segment];
+	}
+
+	return current;
+}
+
+/**
+ * @param {Record<string, unknown> | Array<unknown>} target
+ * @param {Array<string>} path
+ * @param {unknown} value
+ */
+function set_path_value(target, path, value) {
+	let current = target;
+
+	for (let index = 0; index < path.length; index += 1) {
+		const segment = path[index];
+		const is_last = index === path.length - 1;
+		const next_segment = path[index + 1];
+		const next_value =
+			next_segment !== undefined && Number.isInteger(Number(next_segment))
+				? []
+				: {};
+
+		if (Array.isArray(current)) {
+			const array_index = Number(segment);
+			if (!Number.isInteger(array_index) || array_index < 0) {
+				throw new Error(
+					`Invalid array index in field path: ${path.join('.')}`,
+				);
+			}
+
+			if (is_last) {
+				current[array_index] = value;
+				return;
+			}
+
+			current[array_index] ??= next_value;
+			current = /** @type {Record<string, unknown> | Array<unknown>} */ (
+				current[array_index]
+			);
+			continue;
+		}
+
+		if (is_last) {
+			current[segment] = value;
+			return;
+		}
+
+		current[segment] ??= next_value;
+		current = /** @type {Record<string, unknown> | Array<unknown>} */ (
+			current[segment]
+		);
+	}
+}
+
+/**
+ * @param {unknown} value
+ * @param {Array<string>} paths
+ * @returns {unknown}
+ */
+function filter_fields(value, paths) {
+	if (paths.length === 0) return value;
+
+	if (!is_record(value) && !Array.isArray(value)) {
+		throw new Error(
+			'`--fields` can only be used with object or array output',
+		);
+	}
+
+	const result = Array.isArray(value) ? [] : {};
+
+	for (const path of paths) {
+		const segments = split_path(path);
+		if (segments.length === 0) {
+			throw new Error('`--fields` only supports dot-separated paths');
+		}
+		set_path_value(result, segments, get_path_value(value, segments));
 	}
 
 	return result;
 }
 
 /**
- * Validates that all required options are present.
- * @param {Record<string, unknown>} opts
- * @param {InputSchema} input_schema
- * @returns {string | undefined} error message if validation fails
+ * @param {Record<string, unknown>} result
+ * @param {OutputMode} output
+ * @returns {unknown}
  */
-function validate_required(opts, input_schema) {
-	const required = input_schema.required ?? [];
-	const missing = required.filter((name) => opts[name] === undefined);
-
-	if (missing.length > 0) {
-		return `Missing required option(s): ${missing.map((n) => `--${n}`).join(', ')}`;
+function select_output(result, output) {
+	if (output === 'full') return result;
+	if (output === 'structured') {
+		return result.structuredContent ?? null;
 	}
+	if (output === 'content') {
+		return result.content ?? [];
+	}
+	if (output === 'text') {
+		const content = result.content;
+
+		if (!Array.isArray(content)) {
+			throw new Error(
+				'`--output text` requires a tool result with content',
+			);
+		}
+
+		const lines = content.map((item) => {
+			if (
+				!is_record(item) ||
+				item.type !== 'text' ||
+				typeof item.text !== 'string'
+			) {
+				throw new Error(
+					'`--output text` only supports text content blocks',
+				);
+			}
+
+			return item.text;
+		});
+
+		return `${lines.join('\n')}\n`;
+	}
+
+	throw new Error(
+		`Invalid output mode: ${output}. Expected one of full, structured, content, text`,
+	);
 }
 
 /**
- * Validates enum constraints on options.
- * @param {Record<string, unknown>} opts
- * @param {InputSchema} input_schema
- * @returns {string | undefined} error message if validation fails
+ * @param {Record<string, unknown>} result
+ * @param {ToolOptions} options
+ * @returns {string}
  */
-function validate_enums(opts, input_schema) {
-	const properties = input_schema.properties ?? {};
+function format_tool_result(result, options) {
+	const selected = select_output(result, options.output ?? 'full');
 
-	for (const [name, schema] of Object.entries(properties)) {
-		if (schema.enum && opts[name] !== undefined) {
-			if (!schema.enum.includes(opts[name])) {
-				return `Invalid value for --${name}: "${opts[name]}". Must be one of: ${schema.enum.join(', ')}`;
-			}
+	if (typeof selected === 'string') {
+		if (options.fields) {
+			throw new Error('`--fields` cannot be used with `--output text`');
 		}
+		return selected;
 	}
+
+	return format_json(filter_fields(selected, parse_fields(options.fields)));
 }
 
 /**
@@ -149,7 +333,6 @@ export class CliTransport {
 	}
 
 	/**
-	 * Sends a JSON-RPC request to the server and returns the result.
 	 * @param {string} method
 	 * @param {Record<string, unknown>} [params]
 	 * @param {TCustom} [ctx]
@@ -183,41 +366,76 @@ export class CliTransport {
 	}
 
 	/**
-	 * Initialize the MCP session with the server.
+	 * @param {string} method
+	 * @param {Record<string, unknown>} [params]
 	 * @param {TCustom} [ctx]
-	 * @returns {Promise<{ serverInfo?: { name?: string } }>}
 	 */
-	async #initialize(ctx) {
-		return this.#request(
-			'initialize',
-			{
-				protocolVersion: '2025-03-26',
-				capabilities: {},
-				clientInfo: {
-					name: 'tmcp-cli',
-					version: '0.0.1',
+	async #notify(method, params, ctx) {
+		await this.#session_id_storage.run(this.#session_id, () =>
+			this.#server.receive(
+				{
+					jsonrpc: '2.0',
+					method,
+					...(params ? { params } : {}),
 				},
-			},
-			ctx,
+				{
+					sessionId: this.#session_id,
+					custom: ctx,
+				},
+			),
 		);
 	}
 
 	/**
-	 * Fetches the list of tools from the server.
+	 * @param {TCustom} [ctx]
+	 * @returns {Promise<{ serverInfo?: { name?: string } }>}
+	 */
+	async #initialize(ctx) {
+		const result = await this.#request(
+			'initialize',
+			{
+				protocolVersion: '2025-03-26',
+				capabilities: {},
+				clientInfo: CLIENT_INFO,
+			},
+			ctx,
+		);
+
+		await this.#notify('notifications/initialized', undefined, ctx);
+
+		return result;
+	}
+
+	/**
 	 * @param {TCustom} [ctx]
 	 * @returns {Promise<Array<Tool>>}
 	 */
 	async #list_tools(ctx) {
-		const result = await this.#request('tools/list', undefined, ctx);
-		return result?.tools ?? [];
+		/** @type {Array<Tool>} */
+		const tools = [];
+		let cursor = undefined;
+
+		do {
+			const result = /** @type {ListToolsResult | undefined} */ (
+				await this.#request(
+					'tools/list',
+					cursor ? { cursor } : undefined,
+					ctx,
+				)
+			);
+
+			tools.push(...(result?.tools ?? []));
+			cursor = result?.nextCursor;
+		} while (cursor);
+
+		return tools;
 	}
 
 	/**
-	 * Calls a tool by name with arguments.
 	 * @param {string} name
 	 * @param {Record<string, unknown>} [args]
 	 * @param {TCustom} [ctx]
-	 * @returns {Promise<any>}
+	 * @returns {Promise<Record<string, unknown>>}
 	 */
 	async #call_tool(name, args, ctx) {
 		return this.#request(
@@ -231,82 +449,145 @@ export class CliTransport {
 	}
 
 	/**
-	 * Starts the CLI. Initializes the MCP session, lists tools,
-	 * builds sade commands from the tool definitions, and parses argv.
+	 * @param {Map<string, Tool>} tool_map
+	 * @param {string} name
+	 * @returns {Tool}
+	 */
+	#get_tool(tool_map, name) {
+		const tool = tool_map.get(name);
+		if (!tool) {
+			throw new Error(`Unknown tool: ${name}`);
+		}
+		return tool;
+	}
+
+	/**
+	 * @param {Map<string, Tool>} tool_map
+	 * @param {string} name
+	 * @param {string | undefined} input
+	 * @param {ToolOptions} options
+	 * @param {TCustom} [ctx]
+	 */
+	async #run_tool(tool_map, name, input, options, ctx) {
+		const tool = this.#get_tool(tool_map, name);
+		const args = await resolve_tool_input(input);
+		const result = await this.#call_tool(tool.name, args, ctx);
+
+		process.stdout.write(format_tool_result(result, options));
+	}
+
+	/**
 	 * @param {TCustom} [ctx]
 	 * @param {Array<string>} [argv]
 	 */
 	async run(ctx, argv) {
 		const init_result = await this.#initialize(ctx);
-
 		const tools = await this.#list_tools(ctx);
-
 		const script_name = init_result?.serverInfo?.name ?? 'tmcp';
-
 		const prog = sade(script_name);
 
 		/** @type {Map<string, Tool>} */
 		const tool_map = new Map();
 
 		for (const tool of tools) {
-			const properties = tool.inputSchema.properties ?? {};
-			const required = new Set(tool.inputSchema.required ?? []);
-
 			tool_map.set(tool.name, tool);
-
-			const cmd = prog.command(tool.name, tool.description ?? '');
-
-			for (const [name, schema] of Object.entries(properties)) {
-				const opt = build_option(name, schema, required.has(name));
-				cmd.option(opt.flags, opt.description, opt.default_value);
-			}
-
-			// Use a no-op action so sade registers the command.
-			// We'll use lazy parsing to handle async execution ourselves.
-			cmd.action(() => {});
 		}
 
-		// sade expects full process.argv (it slices internally),
-		// but our public API accepts pre-sliced argv for convenience.
-		// Prepend dummy entries when custom argv is provided.
-		const args = argv ? ['node', script_name, ...argv] : process.argv;
+		prog.command('tools', 'List available tools').action(() => {});
+		prog.command('schema <tool>', 'Print a tool schema').action(() => {});
 
+		const call_command = prog
+			.command('call <tool> [input]', 'Call a tool with JSON input')
+			.option(
+				'--output',
+				'Select full, structured, content, or text output',
+				'full',
+			)
+			.option(
+				'--fields',
+				'Select comma-separated dot paths from the chosen output',
+			);
+
+		call_command.action(() => {});
+
+		for (const tool of tools) {
+			if (RESERVED_COMMANDS.has(tool.name)) continue;
+
+			prog.command(`${tool.name} [input]`, tool.description ?? '')
+				.option(
+					'--output',
+					'Select full, structured, content, or text output',
+					'full',
+				)
+				.option(
+					'--fields',
+					'Select comma-separated dot paths from the chosen output',
+				)
+				.action(() => {});
+		}
+
+		const args = argv ? ['node', script_name, ...argv] : process.argv;
 		const parsed = prog.parse(args, { lazy: true });
 
-		// sade returns void when it handles --help/--version or errors
 		if (!parsed) return;
 
 		const { name, args: handler_args } = parsed;
-		const tool = tool_map.get(name);
-
-		if (!tool) return;
-
-		// sade passes positional args followed by opts object.
-		// Our commands have no positional args, so the last (and only) arg is opts.
-		const opts = /** @type {Record<string, unknown>} */ (
-			/** @type {unknown} */ (handler_args[handler_args.length - 1] ?? {})
-		);
+		const { positionals, options } = extract_command_args(handler_args);
 
 		try {
-			const required_error = validate_required(opts, tool.inputSchema);
-			if (required_error) {
-				process.stderr.write(`Error: ${required_error}\n`);
-				process.exitCode = 1;
+			if (name === 'tools') {
+				process.stdout.write(format_json(tools));
 				return;
 			}
 
-			const enum_error = validate_enums(opts, tool.inputSchema);
-			if (enum_error) {
-				process.stderr.write(`Error: ${enum_error}\n`);
-				process.exitCode = 1;
+			if (name === 'schema') {
+				const tool_name = /** @type {string | undefined} */ (
+					positionals[0]
+				);
+				if (!tool_name) {
+					throw new Error('Missing tool name for `schema`');
+				}
+
+				process.stdout.write(
+					format_json(this.#get_tool(tool_map, tool_name)),
+				);
 				return;
 			}
 
-			const coerced = coerce_args(opts, tool.inputSchema);
+			if (name === 'call') {
+				const tool_name = /** @type {string | undefined} */ (
+					positionals[0]
+				);
+				const input = /** @type {string | undefined} */ (
+					positionals[1]
+				);
 
-			const result = await this.#call_tool(tool.name, coerced, ctx);
+				if (!tool_name) {
+					throw new Error('Missing tool name for `call`');
+				}
 
-			process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+				await this.#run_tool(
+					tool_map,
+					tool_name,
+					input,
+					normalize_tool_options(options),
+					ctx,
+				);
+				return;
+			}
+
+			if (tool_map.has(name)) {
+				const input = /** @type {string | undefined} */ (
+					positionals[0]
+				);
+				await this.#run_tool(
+					tool_map,
+					name,
+					input,
+					normalize_tool_options(options),
+					ctx,
+				);
+			}
 		} catch (err) {
 			process.stderr.write(
 				`Error: ${err instanceof Error ? err.message : String(err)}\n`,

--- a/packages/transport-cli/src/index.js
+++ b/packages/transport-cli/src/index.js
@@ -1,76 +1,48 @@
 /**
  * @import { McpServer } from "tmcp";
- * @import { Options } from "yargs";
  * @import { InputSchema, Tool } from "./internal.js";
  */
 import process from 'node:process';
 import { AsyncLocalStorage } from 'node:async_hooks';
-import Yargs from 'yargs/yargs';
+import sade from 'sade';
 
 /**
- * Maps a JSON Schema type string to a yargs option type.
- * @param {string | undefined} json_schema_type
- * @returns {Options["type"]}
+ * @typedef {number | string | boolean | null} SadeValue
  */
-function json_schema_type_to_yargs(json_schema_type) {
-	switch (json_schema_type) {
-		case 'string':
-			return 'string';
-		case 'number':
-		case 'integer':
-			return 'number';
-		case 'boolean':
-			return 'boolean';
-		case 'array':
-			return 'array';
-		default:
-			return 'string';
+
+/**
+ * Builds sade option flags from a JSON Schema property name and schema.
+ * @param {string} name
+ * @param {{ type?: string; description?: string; enum?: Array<unknown>; default?: unknown }} schema
+ * @param {boolean} required
+ * @returns {{ flags: string; description: string; default_value: SadeValue | undefined }}
+ */
+function build_option(name, schema, required) {
+	const flags = `--${name}`;
+
+	let description = schema.description ?? '';
+
+	if (schema.enum) {
+		const choices = schema.enum.join(', ');
+		description += description
+			? ` (choices: ${choices})`
+			: `choices: ${choices}`;
 	}
+
+	if (required) {
+		description += description ? ' (required)' : 'required';
+	}
+
+	return {
+		flags,
+		description,
+		default_value: /** @type {SadeValue | undefined} */ (schema.default),
+	};
 }
 
 /**
- * Converts a JSON Schema inputSchema into a yargs options object.
- * @param {InputSchema} input_schema
- * @returns {Record<string, Options>}
- */
-function json_schema_to_yargs_options(input_schema) {
-	/** @type {Record<string, Options>} */
-	const options = {};
-
-	const properties = input_schema.properties ?? {};
-	const required = new Set(input_schema.required ?? []);
-
-	for (const [name, schema] of Object.entries(properties)) {
-		/** @type {Options} */
-		const option = {};
-
-		option.type = json_schema_type_to_yargs(schema.type);
-		option.demandOption = required.has(name);
-
-		if (schema.description) {
-			option.describe = schema.description;
-		}
-
-		if (schema.enum) {
-			option.choices =
-				/** @type {Array<string | number | true | undefined>} */ (
-					schema.enum
-				);
-		}
-
-		if (schema.default !== undefined) {
-			option.default = schema.default;
-		}
-
-		options[name] = option;
-	}
-
-	return options;
-}
-
-/**
- * Coerces parsed yargs arguments back to their JSON Schema types.
- * Yargs parses everything from argv as strings by default for some types,
+ * Coerces parsed arguments back to their JSON Schema types.
+ * sade parses everything from argv as strings by default,
  * so we need to coerce values based on the schema.
  * @param {Record<string, unknown>} args
  * @param {InputSchema} input_schema
@@ -90,11 +62,19 @@ function coerce_args(args, input_schema) {
 			result[key] = parseInt(value, 10);
 		} else if (schema?.type === 'number' && typeof value === 'string') {
 			result[key] = parseFloat(value);
+		} else if (schema?.type === 'boolean' && typeof value === 'string') {
+			result[key] = value === 'true';
 		} else if (schema?.type === 'object' && typeof value === 'string') {
 			try {
 				result[key] = JSON.parse(value);
 			} catch {
 				result[key] = value;
+			}
+		} else if (schema?.type === 'array' && typeof value === 'string') {
+			try {
+				result[key] = JSON.parse(value);
+			} catch {
+				result[key] = value.split(',');
 			}
 		} else {
 			result[key] = value;
@@ -102,6 +82,39 @@ function coerce_args(args, input_schema) {
 	}
 
 	return result;
+}
+
+/**
+ * Validates that all required options are present.
+ * @param {Record<string, unknown>} opts
+ * @param {InputSchema} input_schema
+ * @returns {string | undefined} error message if validation fails
+ */
+function validate_required(opts, input_schema) {
+	const required = input_schema.required ?? [];
+	const missing = required.filter((name) => opts[name] === undefined);
+
+	if (missing.length > 0) {
+		return `Missing required option(s): ${missing.map((n) => `--${n}`).join(', ')}`;
+	}
+}
+
+/**
+ * Validates enum constraints on options.
+ * @param {Record<string, unknown>} opts
+ * @param {InputSchema} input_schema
+ * @returns {string | undefined} error message if validation fails
+ */
+function validate_enums(opts, input_schema) {
+	const properties = input_schema.properties ?? {};
+
+	for (const [name, schema] of Object.entries(properties)) {
+		if (schema.enum && opts[name] !== undefined) {
+			if (!schema.enum.includes(opts[name])) {
+				return `Invalid value for --${name}: "${opts[name]}". Must be one of: ${schema.enum.join(', ')}`;
+			}
+		}
+	}
 }
 
 /**
@@ -219,7 +232,7 @@ export class CliTransport {
 
 	/**
 	 * Starts the CLI. Initializes the MCP session, lists tools,
-	 * builds yargs commands from the tool definitions, and parses argv.
+	 * builds sade commands from the tool definitions, and parses argv.
 	 * @param {TCustom} [ctx]
 	 * @param {Array<string>} [argv]
 	 */
@@ -230,48 +243,75 @@ export class CliTransport {
 
 		const script_name = init_result?.serverInfo?.name ?? 'tmcp';
 
-		const cli = Yargs(argv ?? process.argv.slice(2))
-			.scriptName(script_name)
-			.strict()
-			.demandCommand(
-				1,
-				'You need to specify a tool command to run. Use --help to see available tools.',
-			)
-			.help();
+		const prog = sade(script_name);
+
+		/** @type {Map<string, Tool>} */
+		const tool_map = new Map();
 
 		for (const tool of tools) {
-			const options = json_schema_to_yargs_options(tool.inputSchema);
+			const properties = tool.inputSchema.properties ?? {};
+			const required = new Set(tool.inputSchema.required ?? []);
 
-			cli.command(
-				tool.name,
-				tool.description ?? '',
-				(yargs) => yargs.options(options),
-				async (args) => {
-					try {
-						const coerced = coerce_args(
-							/** @type {Record<string, unknown>} */ (args),
-							tool.inputSchema,
-						);
+			tool_map.set(tool.name, tool);
 
-						const result = await this.#call_tool(
-							tool.name,
-							coerced,
-							ctx,
-						);
+			const cmd = prog.command(tool.name, tool.description ?? '');
 
-						process.stdout.write(
-							JSON.stringify(result, null, 2) + '\n',
-						);
-					} catch (err) {
-						process.stderr.write(
-							`Error: ${err instanceof Error ? err.message : String(err)}\n`,
-						);
-						process.exitCode = 1;
-					}
-				},
-			);
+			for (const [name, schema] of Object.entries(properties)) {
+				const opt = build_option(name, schema, required.has(name));
+				cmd.option(opt.flags, opt.description, opt.default_value);
+			}
+
+			// Use a no-op action so sade registers the command.
+			// We'll use lazy parsing to handle async execution ourselves.
+			cmd.action(() => {});
 		}
 
-		await cli.parseAsync();
+		// sade expects full process.argv (it slices internally),
+		// but our public API accepts pre-sliced argv for convenience.
+		// Prepend dummy entries when custom argv is provided.
+		const args = argv ? ['node', script_name, ...argv] : process.argv;
+
+		const parsed = prog.parse(args, { lazy: true });
+
+		// sade returns void when it handles --help/--version or errors
+		if (!parsed) return;
+
+		const { name, args: handler_args } = parsed;
+		const tool = tool_map.get(name);
+
+		if (!tool) return;
+
+		// sade passes positional args followed by opts object.
+		// Our commands have no positional args, so the last (and only) arg is opts.
+		const opts = /** @type {Record<string, unknown>} */ (
+			/** @type {unknown} */ (handler_args[handler_args.length - 1] ?? {})
+		);
+
+		try {
+			const required_error = validate_required(opts, tool.inputSchema);
+			if (required_error) {
+				process.stderr.write(`Error: ${required_error}\n`);
+				process.exitCode = 1;
+				return;
+			}
+
+			const enum_error = validate_enums(opts, tool.inputSchema);
+			if (enum_error) {
+				process.stderr.write(`Error: ${enum_error}\n`);
+				process.exitCode = 1;
+				return;
+			}
+
+			const coerced = coerce_args(opts, tool.inputSchema);
+
+			const result = await this.#call_tool(tool.name, coerced, ctx);
+
+			process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+		} catch (err) {
+			process.stderr.write(
+				`Error: ${err instanceof Error ? err.message : String(err)}\n`,
+			);
+			process.exitCode = 1;
+		}
 	}
 }

--- a/packages/transport-cli/src/index.js
+++ b/packages/transport-cli/src/index.js
@@ -368,6 +368,10 @@ export class CliTransport {
 		this.#server = server;
 	}
 
+	#exit() {
+		process.exit(process.exitCode ?? 0);
+	}
+
 	/**
 	 * @param {string} method
 	 * @param {Record<string, unknown>} [params]
@@ -581,16 +585,25 @@ export class CliTransport {
 					.action(() => {});
 			}
 
-			const args = argv ? ['node', script_name, ...argv] : process.argv;
+			const command_args = argv ?? process.argv.slice(2);
+			const args = [
+				'node',
+				script_name,
+				...(command_args.length === 0 ? ['--help'] : command_args),
+			];
 			const parsed = prog.parse(args, { lazy: true });
 
-			if (!parsed) return;
+			if (!parsed) {
+				this.#exit();
+				return;
+			}
 
 			const { name, args: handler_args } = parsed;
 			const { positionals, options } = extract_command_args(handler_args);
 
 			if (name === 'tools') {
 				process.stdout.write(format_json(tools));
+				this.#exit();
 				return;
 			}
 
@@ -605,6 +618,7 @@ export class CliTransport {
 				process.stdout.write(
 					format_json(this.#get_tool(tool_map, tool_name)),
 				);
+				this.#exit();
 				return;
 			}
 
@@ -627,6 +641,7 @@ export class CliTransport {
 					normalize_tool_options(options),
 					ctx,
 				);
+				this.#exit();
 				return;
 			}
 
@@ -641,12 +656,17 @@ export class CliTransport {
 					normalize_tool_options(options),
 					ctx,
 				);
+				this.#exit();
+				return;
 			}
+
+			this.#exit();
 		} catch (err) {
 			process.stderr.write(
 				`Error: ${err instanceof Error ? err.message : String(err)}\n`,
 			);
 			process.exitCode = 1;
+			this.#exit();
 		}
 	}
 }

--- a/packages/transport-cli/src/index.js
+++ b/packages/transport-cli/src/index.js
@@ -1,5 +1,6 @@
 /**
  * @import { McpServer } from "tmcp";
+ * @import { Sade } from "sade";
  * @import { ListToolsResult, Tool } from "./internal.js";
  */
 import process from 'node:process';
@@ -13,6 +14,11 @@ import sade from 'sade';
 
 /**
  * @typedef {{ output?: OutputMode; fields?: string }} ToolOptions
+ */
+
+/**
+ * @typedef {Object} CliTransportOptions
+ * @property {(prog: Sade) => void} [setup] Hook invoked with the configured `sade` instance after built-in commands and tool aliases have been registered, but before parsing. Use it to add custom commands, set a version, examples, etc.
  */
 
 const CLIENT_INFO = {
@@ -362,10 +368,17 @@ export class CliTransport {
 	#session_id = randomUUID();
 
 	/**
-	 * @param {McpServer<any, TCustom>} server
+	 * @type {CliTransportOptions}
 	 */
-	constructor(server) {
+	#options;
+
+	/**
+	 * @param {McpServer<any, TCustom>} server
+	 * @param {CliTransportOptions} [options]
+	 */
+	constructor(server, options = {}) {
 		this.#server = server;
+		this.#options = options;
 	}
 
 	#exit() {
@@ -585,6 +598,31 @@ export class CliTransport {
 					.action(() => {});
 			}
 
+			/** @type {Set<string>} */
+			const custom_commands = new Set();
+
+			if (typeof this.#options.setup === 'function') {
+				const original_command = prog.command.bind(prog);
+				prog.command = (usage, description, options) => {
+					const result = original_command(
+						usage,
+						description,
+						options,
+					);
+					const [head] = String(usage).split(/\s+/);
+					if (head) {
+						custom_commands.add(head);
+					}
+					return result;
+				};
+
+				try {
+					this.#options.setup(prog);
+				} finally {
+					prog.command = original_command;
+				}
+			}
+
 			const command_args = argv ?? process.argv.slice(2);
 			const args = [
 				'node',
@@ -600,6 +638,18 @@ export class CliTransport {
 
 			const { name, args: handler_args } = parsed;
 			const { positionals, options } = extract_command_args(handler_args);
+
+			if (custom_commands.has(name)) {
+				const handler =
+					/** @type {((...args: Array<unknown>) => unknown) | undefined} */ (
+						parsed.handler
+					);
+				if (typeof handler === 'function') {
+					await handler(...handler_args);
+				}
+				this.#exit();
+				return;
+			}
 
 			if (name === 'tools') {
 				process.stdout.write(format_json(tools));

--- a/packages/transport-cli/src/internal.d.ts
+++ b/packages/transport-cli/src/internal.d.ts
@@ -1,0 +1,20 @@
+export type InputSchema = {
+	type: 'object';
+	properties?: Record<
+		string,
+		{
+			type?: string;
+			description?: string;
+			enum?: Array<unknown>;
+			default?: unknown;
+			items?: { type?: string };
+		}
+	>;
+	required?: Array<string>;
+};
+
+export type Tool = {
+	name: string;
+	description?: string;
+	inputSchema: InputSchema;
+};

--- a/packages/transport-cli/src/internal.d.ts
+++ b/packages/transport-cli/src/internal.d.ts
@@ -1,20 +1,35 @@
-export type InputSchema = {
-	type: 'object';
-	properties?: Record<
-		string,
-		{
-			type?: string;
-			description?: string;
-			enum?: Array<unknown>;
-			default?: unknown;
-			items?: { type?: string };
-		}
-	>;
+export type JsonSchema = {
+	type?: string | Array<string>;
+	title?: string;
+	description?: string;
+	default?: unknown;
+	enum?: Array<unknown>;
+	properties?: Record<string, JsonSchema>;
 	required?: Array<string>;
+	items?: JsonSchema | Array<JsonSchema>;
+	additionalProperties?: boolean | JsonSchema;
+	oneOf?: Array<JsonSchema>;
+	anyOf?: Array<JsonSchema>;
+	allOf?: Array<JsonSchema>;
+	[key: string]: unknown;
+};
+
+export type InputSchema = JsonSchema & {
+	type: 'object';
 };
 
 export type Tool = {
 	name: string;
+	title?: string;
 	description?: string;
+	icons?: Array<unknown>;
+	annotations?: Record<string, unknown>;
+	_meta?: Record<string, unknown>;
 	inputSchema: InputSchema;
+	outputSchema?: JsonSchema;
+};
+
+export type ListToolsResult = {
+	tools: Array<Tool>;
+	nextCursor?: string;
 };

--- a/packages/transport-cli/src/test.js
+++ b/packages/transport-cli/src/test.js
@@ -1,0 +1,5 @@
+import Yargs from 'yargs/yargs';
+
+await Yargs(process.argv.slice(2))
+	.command('test', 'Run tests', {}, console.log)
+	.parseAsync();

--- a/packages/transport-cli/src/test.js
+++ b/packages/transport-cli/src/test.js
@@ -1,5 +1,0 @@
-import Yargs from 'yargs/yargs';
-
-await Yargs(process.argv.slice(2))
-	.command('test', 'Run tests', {}, console.log)
-	.parseAsync();

--- a/packages/transport-cli/src/types/index.d.ts
+++ b/packages/transport-cli/src/types/index.d.ts
@@ -1,0 +1,18 @@
+declare module '@tmcp/transport-cli' {
+	import type { McpServer } from 'tmcp';
+	export class CliTransport<TCustom extends Record<string, unknown> | undefined = undefined> {
+		
+		constructor(server: McpServer<any, TCustom>);
+		/**
+		 * Starts the CLI. Initializes the MCP session, lists tools,
+		 * builds yargs commands from the tool definitions, and parses argv.
+		 * 
+		 */
+		run(ctx?: TCustom, argv?: Array<string>): Promise<void>;
+		#private;
+	}
+
+	export {};
+}
+
+//# sourceMappingURL=index.d.ts.map

--- a/packages/transport-cli/src/types/index.d.ts
+++ b/packages/transport-cli/src/types/index.d.ts
@@ -3,14 +3,15 @@ declare module '@tmcp/transport-cli' {
 	export class CliTransport<TCustom extends Record<string, unknown> | undefined = undefined> {
 		
 		constructor(server: McpServer<any, TCustom>);
-		/**
-		 * Starts the CLI. Initializes the MCP session, lists tools,
-		 * builds yargs commands from the tool definitions, and parses argv.
-		 * 
-		 */
+		
 		run(ctx?: TCustom, argv?: Array<string>): Promise<void>;
 		#private;
 	}
+	export type OutputMode = "full" | "structured" | "content" | "text";
+	export type ToolOptions = {
+		output?: OutputMode;
+		fields?: string;
+	};
 
 	export {};
 }

--- a/packages/transport-cli/src/types/index.d.ts
+++ b/packages/transport-cli/src/types/index.d.ts
@@ -1,8 +1,9 @@
 declare module '@tmcp/transport-cli' {
 	import type { McpServer } from 'tmcp';
+	import type { default as sade } from 'sade';
 	export class CliTransport<TCustom extends Record<string, unknown> | undefined = undefined> {
 		
-		constructor(server: McpServer<any, TCustom>);
+		constructor(server: McpServer<any, TCustom>, options?: CliTransportOptions);
 		
 		run(ctx?: TCustom, argv?: Array<string>): Promise<void>;
 		#private;
@@ -11,6 +12,12 @@ declare module '@tmcp/transport-cli' {
 	export type ToolOptions = {
 		output?: OutputMode;
 		fields?: string;
+	};
+	export type CliTransportOptions = {
+		/**
+		 * Hook invoked with the configured `sade` instance after built-in commands and tool aliases have been registered, but before parsing. Use it to add custom commands, set a version, examples, etc.
+		 */
+		setup?: ((prog: sade.Sade) => void) | undefined;
 	};
 
 	export {};

--- a/packages/transport-cli/src/types/index.d.ts.map
+++ b/packages/transport-cli/src/types/index.d.ts.map
@@ -2,7 +2,9 @@
 	"version": 3,
 	"file": "index.d.ts",
 	"names": [
-		"CliTransport"
+		"CliTransport",
+		"OutputMode",
+		"ToolOptions"
 	],
 	"sources": [
 		"../index.js"
@@ -10,6 +12,6 @@
 	"sourcesContent": [
 		null
 	],
-	"mappings": ";;cA6GaA,YAAYA",
+	"mappings": ";;cAkTaA,YAAYA;;;;;;;aAzSgCC,UAAUA;aAIZC,WAAWA",
 	"ignoreList": []
 }

--- a/packages/transport-cli/src/types/index.d.ts.map
+++ b/packages/transport-cli/src/types/index.d.ts.map
@@ -1,0 +1,15 @@
+{
+	"version": 3,
+	"file": "index.d.ts",
+	"names": [
+		"CliTransport"
+	],
+	"sources": [
+		"../index.js"
+	],
+	"sourcesContent": [
+		null
+	],
+	"mappings": ";;cA6GaA,YAAYA",
+	"ignoreList": []
+}

--- a/packages/transport-cli/src/types/index.d.ts.map
+++ b/packages/transport-cli/src/types/index.d.ts.map
@@ -12,6 +12,6 @@
 	"sourcesContent": [
 		null
 	],
-	"mappings": ";;cAkTaA,YAAYA;;;;;;;aAzSgCC,UAAUA;aAIZC,WAAWA",
+	"mappings": ";;cAsVaA,YAAYA;;;;;;;aA5UgCC,UAAUA;aAIZC,WAAWA",
 	"ignoreList": []
 }

--- a/packages/transport-cli/src/types/index.d.ts.map
+++ b/packages/transport-cli/src/types/index.d.ts.map
@@ -12,6 +12,6 @@
 	"sourcesContent": [
 		null
 	],
-	"mappings": ";;cAsVaA,YAAYA;;;;;;;aA5UgCC,UAAUA;aAIZC,WAAWA",
+	"mappings": ";;;cA4VaA,YAAYA;;;;;;;aAjVgCC,UAAUA;aAIZC,WAAWA",
 	"ignoreList": []
 }

--- a/packages/transport-cli/test/index.test.js
+++ b/packages/transport-cli/test/index.test.js
@@ -165,6 +165,30 @@ describe('CliTransport', () => {
 	});
 
 	describe('tool invocation', () => {
+		it('prints initialization failures through stderr instead of throwing', async () => {
+			const server = create_server();
+			const receive_spy = vi.spyOn(server, 'receive');
+
+			receive_spy.mockResolvedValueOnce(
+				/** @type {any} */ ({
+					jsonrpc: '2.0',
+					id: 0,
+					error: {
+						code: -32600,
+						message: 'Initialization failed',
+					},
+				}),
+			);
+
+			const cli = new CliTransport(server);
+			await expect(
+				cli.run(undefined, ['tools']),
+			).resolves.toBeUndefined();
+
+			expect(stderr_text()).toContain('Error: Initialization failed');
+			expect(process.exitCode).toBe(1);
+		});
+
 		it('calls tools through the static call command', async () => {
 			const server = create_server();
 
@@ -214,6 +238,41 @@ describe('CliTransport', () => {
 			await cli.run(undefined, ['sum', '{"a":3,"b":4}']);
 
 			expect(stdout_json().structuredContent).toEqual({ total: 7 });
+		});
+
+		it('skips unsafe aliases without breaking other commands', async () => {
+			const server = create_server();
+
+			server.tool(
+				{ name: 'safe_tool', description: 'Safe tool' },
+				() => ({
+					content: [{ type: 'text', text: 'safe' }],
+				}),
+			);
+
+			server.tool(
+				{ name: 'get<resource>', description: 'Unsafe alias tool' },
+				() => ({
+					content: [{ type: 'text', text: 'unsafe' }],
+				}),
+			);
+
+			const safe_cli = new CliTransport(server);
+			await safe_cli.run(undefined, ['safe_tool']);
+			expect(stdout_json().content[0].text).toBe('safe');
+			expect(stderr_text()).toContain(
+				'Warning: skipping bare alias for tool "get<resource>"',
+			);
+
+			stdout_chunks = [];
+			stderr_chunks = [];
+
+			const unsafe_cli = new CliTransport(server);
+			await unsafe_cli.run(undefined, ['call', 'get<resource>']);
+			expect(stdout_json().content[0].text).toBe('unsafe');
+			expect(stderr_text()).toContain(
+				'Use `call get<resource>` instead.',
+			);
 		});
 
 		it('passes custom context to the server', async () => {

--- a/packages/transport-cli/test/index.test.js
+++ b/packages/transport-cli/test/index.test.js
@@ -374,6 +374,29 @@ describe('CliTransport', () => {
 			expect(stderr_text()).toContain('Error:');
 			expect(process.exitCode).toBe(1);
 		});
+
+		it('writes tool-level isError responses to stderr', async () => {
+			const server = create_server();
+			server.tool(
+				{
+					name: 'greet',
+					description: 'Greet someone',
+					schema: v.object({
+						name: v.string(),
+					}),
+				},
+				() => ({
+					content: [{ type: 'text', text: 'ok' }],
+				}),
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['greet', '{}']);
+
+			expect(stderr_text()).toContain('Invalid arguments');
+			expect(process.exitCode).toBe(1);
+			expect(stdout_text()).toBe('');
+		});
 	});
 
 	describe('output controls', () => {

--- a/packages/transport-cli/test/index.test.js
+++ b/packages/transport-cli/test/index.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { McpServer } from 'tmcp';
 import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
 import * as v from 'valibot';
@@ -12,6 +12,24 @@ const server_config = {
 	description: 'A test CLI server',
 };
 
+/**
+ * @param {Partial<ConstructorParameters<typeof McpServer>[0]>} [config]
+ * @param {Partial<ConstructorParameters<typeof McpServer>[1]>} [options]
+ */
+function create_server(config = {}, options = {}) {
+	return new McpServer(
+		{
+			...server_config,
+			...config,
+		},
+		{
+			adapter,
+			capabilities: { tools: {} },
+			...options,
+		},
+	);
+}
+
 describe('CliTransport', () => {
 	/** @type {string[]} */
 	let stdout_chunks;
@@ -19,9 +37,14 @@ describe('CliTransport', () => {
 	/** @type {string[]} */
 	let stderr_chunks;
 
+	/** @type {string | number | null | undefined} */
+	let original_exit_code;
+
 	beforeEach(() => {
 		stdout_chunks = [];
 		stderr_chunks = [];
+		original_exit_code = process.exitCode;
+		process.exitCode = undefined;
 
 		vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
 			stdout_chunks.push(String(chunk));
@@ -34,40 +57,116 @@ describe('CliTransport', () => {
 		});
 	});
 
-	describe('tool without arguments', () => {
-		it('should execute a tool with no input schema and print JSON result', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
+	afterEach(() => {
+		vi.restoreAllMocks();
+		process.exitCode = original_exit_code;
+	});
+
+	function stdout_text() {
+		return stdout_chunks.join('');
+	}
+
+	function stderr_text() {
+		return stderr_chunks.join('');
+	}
+
+	function stdout_json() {
+		return JSON.parse(stdout_text());
+	}
+
+	describe('tools command', () => {
+		it('lists tools across paginated responses and sends initialized first', async () => {
+			const server = create_server(undefined, {
+				pagination: {
+					tools: {
+						size: 1,
+					},
+				},
 			});
 
-			server.tool(
-				{
-					name: 'ping',
-					description: 'Ping the server',
-				},
-				() => {
-					return {
-						content: [{ type: 'text', text: 'pong' }],
-					};
-				},
-			);
+			server.tool({ name: 'first', description: 'first tool' }, () => ({
+				content: [{ type: 'text', text: 'one' }],
+			}));
+			server.tool({ name: 'second', description: 'second tool' }, () => ({
+				content: [{ type: 'text', text: 'two' }],
+			}));
+			server.tool({ name: 'third', description: 'third tool' }, () => ({
+				content: [{ type: 'text', text: 'three' }],
+			}));
 
+			const receive_spy = vi.spyOn(server, 'receive');
 			const cli = new CliTransport(server);
-			await cli.run(undefined, ['ping']);
 
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([{ type: 'text', text: 'pong' }]);
+			await cli.run(undefined, ['tools']);
+
+			const listed_tools = /** @type {Array<{ name: string }>} */ (
+				stdout_json()
+			);
+			expect(listed_tools.map((tool) => tool.name)).toEqual([
+				'first',
+				'second',
+				'third',
+			]);
+
+			const methods = receive_spy.mock.calls.map(
+				([request]) =>
+					/** @type {{ method?: string }} */ (request).method,
+			);
+			expect(methods[0]).toBe('initialize');
+			expect(methods[1]).toBe('notifications/initialized');
+			expect(methods.slice(2)).toEqual([
+				'tools/list',
+				'tools/list',
+				'tools/list',
+			]);
 		});
 	});
 
-	describe('tool with string arguments', () => {
-		it('should pass string arguments to the tool', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
+	describe('schema command', () => {
+		it('prints tool metadata, input schema, and output schema', async () => {
+			const server = create_server();
+
+			server.tool(
+				{
+					name: 'greet',
+					description: 'Greet someone',
+					schema: v.object({
+						name: v.string(),
+					}),
+					outputSchema: v.object({
+						message: v.string(),
+					}),
+				},
+				(input) => ({
+					content: [{ type: 'text', text: `Hello, ${input.name}!` }],
+					structuredContent: { message: `Hello, ${input.name}!` },
+				}),
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['schema', 'greet']);
+
+			const schema = stdout_json();
+			expect(schema.name).toBe('greet');
+			expect(schema.inputSchema.type).toBe('object');
+			expect(schema.outputSchema.type).toBe('object');
+			expect(schema.outputSchema.properties.message.type).toBe('string');
+		});
+
+		it('errors on unknown tools', async () => {
+			const server = create_server();
+			const cli = new CliTransport(server);
+
+			await cli.run(undefined, ['schema', 'missing']);
+
+			expect(stderr_text()).toContain('Unknown tool: missing');
+			expect(process.exitCode).toBe(1);
+		});
+	});
+
+	describe('tool invocation', () => {
+		it('calls tools through the static call command', async () => {
+			const server = create_server();
 
 			server.tool(
 				{
@@ -77,516 +176,52 @@ describe('CliTransport', () => {
 						name: v.string(),
 					}),
 				},
-				(params) => {
-					return {
-						content: [
-							{ type: 'text', text: `Hello, ${params.name}!` },
-						],
-					};
-				},
+				(input) => ({
+					content: [{ type: 'text', text: `Hello, ${input.name}!` }],
+				}),
 			);
 
 			const cli = new CliTransport(server);
-			await cli.run(undefined, ['greet', '--name', 'Alice']);
+			await cli.run(undefined, ['call', 'greet', '{"name":"Alice"}']);
 
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([
+			expect(stdout_json().content).toEqual([
 				{ type: 'text', text: 'Hello, Alice!' },
 			]);
 		});
-	});
 
-	describe('tool with number arguments', () => {
-		it('should parse and pass number arguments', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
+		it('calls tools through the bare tool alias', async () => {
+			const server = create_server();
 
 			server.tool(
 				{
-					name: 'add',
+					name: 'sum',
 					description: 'Add two numbers',
 					schema: v.object({
 						a: v.number(),
 						b: v.number(),
 					}),
 				},
-				(params) => {
-					return {
+				(input) =>
+					/** @type {any} */ ({
 						content: [
-							{
-								type: 'text',
-								text: `${params.a + params.b}`,
-							},
+							{ type: 'text', text: `${input.a + input.b}` },
 						],
-					};
-				},
-			);
-
-			const cli = new CliTransport(server);
-			await cli.run(undefined, ['add', '--a', '3', '--b', '4']);
-
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([{ type: 'text', text: '7' }]);
-		});
-	});
-
-	describe('tool with boolean arguments', () => {
-		it('should parse and pass boolean arguments', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
-			server.tool(
-				{
-					name: 'toggle',
-					description: 'Toggle a flag',
-					schema: v.object({
-						verbose: v.boolean(),
+						structuredContent: { total: input.a + input.b },
 					}),
-				},
-				(params) => {
-					return {
-						content: [
-							{
-								type: 'text',
-								text: params.verbose ? 'verbose' : 'quiet',
-							},
-						],
-					};
-				},
 			);
 
 			const cli = new CliTransport(server);
-			await cli.run(undefined, ['toggle', '--verbose']);
+			await cli.run(undefined, ['sum', '{"a":3,"b":4}']);
 
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([{ type: 'text', text: 'verbose' }]);
+			expect(stdout_json().structuredContent).toEqual({ total: 7 });
 		});
 
-		it('should handle --no- prefix for boolean false', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
-			server.tool(
-				{
-					name: 'toggle',
-					description: 'Toggle a flag',
-					schema: v.object({
-						verbose: v.boolean(),
-					}),
-				},
-				(params) => {
-					return {
-						content: [
-							{
-								type: 'text',
-								text: params.verbose ? 'verbose' : 'quiet',
-							},
-						],
-					};
-				},
-			);
-
-			const cli = new CliTransport(server);
-			await cli.run(undefined, ['toggle', '--no-verbose']);
-
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([{ type: 'text', text: 'quiet' }]);
-		});
-
-		it('should handle kebab-case arguments', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
-			server.tool(
-				{
-					name: 'toggle',
-					description: 'Toggle a flag',
-					schema: v.object({
-						'kebab-case': v.boolean(),
-					}),
-				},
-				(params) => {
-					return {
-						content: [
-							{
-								type: 'text',
-								text: params['kebab-case']
-									? 'kebab-case'
-									: 'camelCase',
-							},
-						],
-					};
-				},
-			);
-
-			const cli = new CliTransport(server);
-			await cli.run(undefined, ['toggle', '--kebab-case']);
-
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([
-				{ type: 'text', text: 'kebab-case' },
-			]);
-		});
-	});
-
-	describe('tool with optional arguments', () => {
-		it('should handle optional arguments that are not provided', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
-			server.tool(
-				{
-					name: 'greet',
-					description: 'Greet someone',
-					schema: v.object({
-						name: v.string(),
-						greeting: v.optional(v.string()),
-					}),
-				},
-				(params) => {
-					const greeting = params.greeting ?? 'Hello';
-					return {
-						content: [
-							{
-								type: 'text',
-								text: `${greeting}, ${params.name}!`,
-							},
-						],
-					};
-				},
-			);
-
-			const cli = new CliTransport(server);
-			await cli.run(undefined, ['greet', '--name', 'Bob']);
-
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([
-				{ type: 'text', text: 'Hello, Bob!' },
-			]);
-		});
-
-		it('should pass optional arguments when provided', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
-			server.tool(
-				{
-					name: 'greet',
-					description: 'Greet someone',
-					schema: v.object({
-						name: v.string(),
-						greeting: v.optional(v.string()),
-					}),
-				},
-				(params) => {
-					const greeting = params.greeting ?? 'Hello';
-					return {
-						content: [
-							{
-								type: 'text',
-								text: `${greeting}, ${params.name}!`,
-							},
-						],
-					};
-				},
-			);
-
-			const cli = new CliTransport(server);
-			await cli.run(undefined, [
-				'greet',
-				'--name',
-				'Bob',
-				'--greeting',
-				'Hi',
-			]);
-
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([
-				{ type: 'text', text: 'Hi, Bob!' },
-			]);
-		});
-	});
-
-	describe('tool with enum arguments', () => {
-		it('should accept valid enum values', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
-			server.tool(
-				{
-					name: 'set_level',
-					description: 'Set log level',
-					schema: v.object({
-						level: v.picklist(['debug', 'info', 'warn', 'error']),
-					}),
-				},
-				(params) => {
-					return {
-						content: [
-							{
-								type: 'text',
-								text: `Level set to ${params.level}`,
-							},
-						],
-					};
-				},
-			);
-
-			const cli = new CliTransport(server);
-			await cli.run(undefined, ['set_level', '--level', 'debug']);
-
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([
-				{ type: 'text', text: 'Level set to debug' },
-			]);
-		});
-	});
-
-	describe('multiple tools', () => {
-		it('should register all tools as commands', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
-			server.tool(
-				{
-					name: 'tool_a',
-					description: 'Tool A',
-				},
-				() => ({
-					content: [{ type: 'text', text: 'A' }],
-				}),
-			);
-
-			server.tool(
-				{
-					name: 'tool_b',
-					description: 'Tool B',
-				},
-				() => ({
-					content: [{ type: 'text', text: 'B' }],
-				}),
-			);
-
-			// Call tool_a
-			const cli_a = new CliTransport(server);
-			await cli_a.run(undefined, ['tool_a']);
-
-			expect(stdout_chunks.length).toBe(1);
-			let result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([{ type: 'text', text: 'A' }]);
-
-			// Reset output
-			stdout_chunks = [];
-
-			// Call tool_b
-			const cli_b = new CliTransport(server);
-			await cli_b.run(undefined, ['tool_b']);
-
-			expect(stdout_chunks.length).toBe(1);
-			result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([{ type: 'text', text: 'B' }]);
-		});
-	});
-
-	describe('tool with mixed argument types', () => {
-		it('should handle a tool with string, number, and boolean arguments', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
-			server.tool(
-				{
-					name: 'create_user',
-					description: 'Create a user',
-					schema: v.object({
-						name: v.string(),
-						age: v.number(),
-						admin: v.optional(v.boolean()),
-					}),
-				},
-				(params) => {
-					return {
-						content: [
-							{
-								type: 'text',
-								text: JSON.stringify({
-									name: params.name,
-									age: params.age,
-									admin: params.admin ?? false,
-								}),
-							},
-						],
-					};
-				},
-			);
-
-			const cli = new CliTransport(server);
-			await cli.run(undefined, [
-				'create_user',
-				'--name',
-				'Charlie',
-				'--age',
-				'30',
-				'--admin',
-			]);
-
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			const parsed = JSON.parse(result.content[0].text);
-			expect(parsed).toEqual({
-				name: 'Charlie',
-				age: 30,
-				admin: true,
-			});
-		});
-	});
-
-	describe('tool execution error', () => {
-		it('should write errors to stderr and set exit code', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
-			server.tool(
-				{
-					name: 'failing_tool',
-					description: 'A tool that throws',
-				},
-				() => {
-					throw new Error('Something went wrong');
-				},
-			);
-
-			const cli = new CliTransport(server);
-
-			// Save and restore process.exitCode
-			const original_exit_code = process.exitCode;
-
-			await cli.run(undefined, ['failing_tool']);
-
-			// When a tool throws, the MCP server returns a JSON-RPC error,
-			// which the transport catches and writes to stderr
-			expect(stderr_chunks.length).toBeGreaterThan(0);
-			expect(stderr_chunks.join('')).toContain('Error:');
-			expect(process.exitCode).toBe(1);
-
-			process.exitCode = original_exit_code;
-		});
-	});
-
-	describe('output format', () => {
-		it('should output pretty-printed JSON', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
-			server.tool(
-				{
-					name: 'format_test',
-					description: 'Test output format',
-				},
-				() => ({
-					content: [{ type: 'text', text: 'test' }],
-				}),
-			);
-
-			const cli = new CliTransport(server);
-			await cli.run(undefined, ['format_test']);
-
-			expect(stdout_chunks.length).toBe(1);
-			// Verify it's pretty-printed (contains newlines and indentation)
-			expect(stdout_chunks[0]).toContain('\n');
-			expect(stdout_chunks[0]).toContain('  ');
-			// Verify it ends with a newline
-			expect(stdout_chunks[0].endsWith('\n')).toBe(true);
-			// Verify it's valid JSON
-			expect(() => JSON.parse(stdout_chunks[0])).not.toThrow();
-		});
-	});
-
-	describe('tool with array arguments', () => {
-		it('should parse array arguments', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
-			server.tool(
-				{
-					name: 'list_items',
-					description: 'List items',
-					schema: v.object({
-						items: v.array(v.string()),
-					}),
-				},
-				(params) => {
-					return {
-						content: [
-							{
-								type: 'text',
-								text: params.items.join(', '),
-							},
-						],
-					};
-				},
-			);
-
-			const cli = new CliTransport(server);
-			await cli.run(undefined, [
-				'list_items',
-				'--items',
-				'foo',
-				'--items',
-				'bar',
-				'--items',
-				'baz',
-			]);
-
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([
-				{ type: 'text', text: 'foo, bar, baz' },
-			]);
-		});
-	});
-
-	describe('custom context', () => {
-		it('should pass custom context to the server', async () => {
+		it('passes custom context to the server', async () => {
 			/** @type {{ userId: string } | undefined} */
 			let captured_ctx;
 
 			const server = /** @type {McpServer<any, { userId: string }>} */ (
-				new McpServer(server_config, {
-					adapter,
-					capabilities: { tools: {} },
-				})
+				/** @type {unknown} */ (create_server())
 			);
 
 			server.tool(
@@ -600,7 +235,7 @@ describe('CliTransport', () => {
 						content: [
 							{
 								type: 'text',
-								text: `user: ${server.ctx.custom?.userId}`,
+								text: server.ctx.custom?.userId ?? '',
 							},
 						],
 					};
@@ -611,75 +246,20 @@ describe('CliTransport', () => {
 				new CliTransport(server)
 			);
 
-			// Note: custom context is not passed through run() in this transport
-			// because the CLI doesn't have a way to inject it from argv.
-			// But we test that the run() method accepts it.
 			await cli.run({ userId: 'test-user' }, ['ctx_tool']);
 
-			expect(stdout_chunks.length).toBe(1);
 			expect(captured_ctx).toEqual({ userId: 'test-user' });
 		});
-	});
 
-	describe('tool with description in schema properties', () => {
-		it('should use property descriptions from schema', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
+		it('errors on invalid positional JSON', async () => {
+			const server = create_server();
 			server.tool(
 				{
-					name: 'described_tool',
-					description: 'Tool with described args',
+					name: 'greet',
+					description: 'Greet someone',
 					schema: v.object({
-						query: v.pipe(
-							v.string(),
-							v.description('The search query'),
-						),
+						name: v.string(),
 					}),
-				},
-				(params) => {
-					return {
-						content: [
-							{
-								type: 'text',
-								text: `Searching: ${params.query}`,
-							},
-						],
-					};
-				},
-			);
-
-			const cli = new CliTransport(server);
-			await cli.run(undefined, ['described_tool', '--query', 'hello']);
-
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([
-				{ type: 'text', text: 'Searching: hello' },
-			]);
-		});
-	});
-
-	describe('script name', () => {
-		it('should use the server name as the CLI script name', async () => {
-			const server = new McpServer(
-				{
-					name: 'my-custom-cli',
-					version: '1.0.0',
-					description: 'A custom CLI server',
-				},
-				{
-					adapter,
-					capabilities: { tools: {} },
-				},
-			);
-
-			server.tool(
-				{
-					name: 'noop',
-					description: 'Does nothing',
 				},
 				() => ({
 					content: [{ type: 'text', text: 'ok' }],
@@ -687,80 +267,261 @@ describe('CliTransport', () => {
 			);
 
 			const cli = new CliTransport(server);
+			await cli.run(undefined, ['greet', '{bad json']);
 
-			/** @type {string[]} */
-			const log_chunks = [];
-
-			const exit_spy = vi
-				.spyOn(process, 'exit')
-				// @ts-expect-error -- mock needs to not actually exit
-				.mockImplementation(() => {});
-
-			const log_spy = vi
-				.spyOn(console, 'log')
-				.mockImplementation((...args) => {
-					log_chunks.push(args.join(' '));
-				});
-
-			const error_spy = vi
-				.spyOn(console, 'error')
-				.mockImplementation((...args) => {
-					log_chunks.push(args.join(' '));
-				});
-
-			try {
-				await cli.run(undefined, ['--help']);
-			} catch {
-				// yargs may throw after calling process.exit
-			}
-
-			const all_output =
-				log_chunks.join('\n') +
-				stdout_chunks.join('') +
-				stderr_chunks.join('');
-			expect(all_output).toContain('my-custom-cli');
-
-			exit_spy.mockRestore();
-			log_spy.mockRestore();
-			error_spy.mockRestore();
+			expect(stderr_text()).toContain('Invalid JSON in positional input');
+			expect(process.exitCode).toBe(1);
 		});
-	});
 
-	describe('tool with integer arguments', () => {
-		it('should handle integer schema types', async () => {
-			const server = new McpServer(server_config, {
-				adapter,
-				capabilities: { tools: {} },
-			});
-
+		it('errors when the input JSON is not an object', async () => {
+			const server = create_server();
 			server.tool(
 				{
-					name: 'count',
-					description: 'Count items',
+					name: 'greet',
+					description: 'Greet someone',
 					schema: v.object({
-						n: v.pipe(v.number(), v.integer()),
+						name: v.string(),
 					}),
 				},
-				(params) => {
-					return {
-						content: [
-							{
-								type: 'text',
-								text: `Count: ${params.n}`,
-							},
-						],
-					};
+				() => ({
+					content: [{ type: 'text', text: 'ok' }],
+				}),
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['greet', '[]']);
+
+			expect(stderr_text()).toContain(
+				'Input from positional input must be a JSON object',
+			);
+			expect(process.exitCode).toBe(1);
+		});
+
+		it('writes tool execution errors to stderr', async () => {
+			const server = create_server();
+			server.tool(
+				{
+					name: 'failing_tool',
+					description: 'A tool that throws',
+				},
+				() => {
+					throw new Error('Something went wrong');
 				},
 			);
 
 			const cli = new CliTransport(server);
-			await cli.run(undefined, ['count', '--n', '42']);
+			await cli.run(undefined, ['failing_tool']);
 
-			expect(stdout_chunks.length).toBe(1);
-			const result = JSON.parse(stdout_chunks[0]);
-			expect(result.content).toEqual([
-				{ type: 'text', text: 'Count: 42' },
+			expect(stderr_text()).toContain('Error:');
+			expect(process.exitCode).toBe(1);
+		});
+	});
+
+	describe('output controls', () => {
+		it('supports structured output', async () => {
+			const server = create_server();
+			server.tool(
+				{
+					name: 'get_user',
+					description: 'Get a user',
+					schema: v.object({
+						id: v.string(),
+					}),
+				},
+				(input) =>
+					/** @type {any} */ ({
+						content: [{ type: 'text', text: `User ${input.id}` }],
+						structuredContent: {
+							user: {
+								id: input.id,
+								name: 'Alice',
+							},
+						},
+					}),
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, [
+				'get_user',
+				'{"id":"1"}',
+				'--output',
+				'structured',
 			]);
+
+			expect(stdout_json()).toEqual({
+				user: { id: '1', name: 'Alice' },
+			});
+		});
+
+		it('supports text output', async () => {
+			const server = create_server();
+			server.tool(
+				{
+					name: 'get_lines',
+					description: 'Get text lines',
+				},
+				() => ({
+					content: [
+						{ type: 'text', text: 'alpha' },
+						{ type: 'text', text: 'beta' },
+					],
+				}),
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['get_lines', '--output', 'text']);
+
+			expect(stdout_text()).toBe('alpha\nbeta\n');
+		});
+
+		it('supports field filtering on the selected output', async () => {
+			const server = create_server();
+			server.tool(
+				{
+					name: 'get_user',
+					description: 'Get a user',
+					schema: v.object({
+						id: v.string(),
+					}),
+				},
+				(input) =>
+					/** @type {any} */ ({
+						content: [{ type: 'text', text: `User ${input.id}` }],
+						structuredContent: {
+							user: {
+								id: input.id,
+								name: 'Alice',
+								email: 'alice@example.com',
+							},
+						},
+					}),
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, [
+				'get_user',
+				'{"id":"1"}',
+				'--output',
+				'structured',
+				'--fields',
+				'user.name',
+			]);
+
+			expect(stdout_json()).toEqual({
+				user: { name: 'Alice' },
+			});
+		});
+
+		it('errors when text output contains non-text blocks', async () => {
+			const server = create_server();
+			server.tool(
+				{
+					name: 'mixed_content',
+					description: 'Return mixed content',
+				},
+				() => ({
+					content: [
+						{ type: 'text', text: 'alpha' },
+						{ type: 'image', data: 'YWJj', mimeType: 'image/png' },
+					],
+				}),
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['mixed_content', '--output', 'text']);
+
+			expect(stderr_text()).toContain(
+				'`--output text` only supports text content blocks',
+			);
+			expect(process.exitCode).toBe(1);
+		});
+
+		it('errors when fields are requested for text output', async () => {
+			const server = create_server();
+			server.tool(
+				{
+					name: 'get_lines',
+					description: 'Get text lines',
+				},
+				() => ({
+					content: [{ type: 'text', text: 'alpha' }],
+				}),
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, [
+				'get_lines',
+				'--output',
+				'text',
+				'--fields',
+				'content.0.text',
+			]);
+
+			expect(stderr_text()).toContain(
+				'`--fields` cannot be used with `--output text`',
+			);
+			expect(process.exitCode).toBe(1);
+		});
+
+		it('errors on unknown field paths', async () => {
+			const server = create_server();
+			server.tool(
+				{
+					name: 'get_user',
+					description: 'Get a user',
+				},
+				() =>
+					/** @type {any} */ ({
+						structuredContent: {
+							user: { name: 'Alice' },
+						},
+					}),
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, [
+				'get_user',
+				'--output',
+				'structured',
+				'--fields',
+				'user.email',
+			]);
+
+			expect(stderr_text()).toContain('Unknown field path: user.email');
+			expect(process.exitCode).toBe(1);
+		});
+	});
+
+	describe('help output', () => {
+		it('uses the server name in help output', async () => {
+			const server = create_server({ name: 'my-custom-cli' });
+			server.tool({ name: 'noop', description: 'Does nothing' }, () => ({
+				content: [{ type: 'text', text: 'ok' }],
+			}));
+
+			const cli = new CliTransport(server);
+			const exit_spy = vi
+				.spyOn(process, 'exit')
+				// @ts-expect-error test helper
+				.mockImplementation(() => {});
+			const log_spy = vi
+				.spyOn(console, 'log')
+				.mockImplementation(() => {});
+
+			try {
+				await cli.run(undefined, ['--help']);
+			} catch {
+				// sade may throw after trying to exit.
+			}
+
+			expect(
+				stdout_text() +
+					stderr_text() +
+					log_spy.mock.calls.flat().join(' '),
+			).toContain('my-custom-cli');
+
+			exit_spy.mockRestore();
+			log_spy.mockRestore();
 		});
 	});
 });

--- a/packages/transport-cli/test/index.test.js
+++ b/packages/transport-cli/test/index.test.js
@@ -471,6 +471,49 @@ describe('CliTransport', () => {
 			});
 		});
 
+		it('does not mutate the original result for overlapping field paths', async () => {
+			const server = create_server();
+			const structured_content = {
+				user: {
+					name: 'Alice',
+					email: 'alice@example.com',
+				},
+			};
+
+			server.tool(
+				{
+					name: 'get_user',
+					description: 'Get a user',
+				},
+				() =>
+					/** @type {any} */ ({
+						structuredContent: structured_content,
+					}),
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, [
+				'get_user',
+				'--output',
+				'structured',
+				'--fields',
+				'user,user.name',
+			]);
+
+			expect(stdout_json()).toEqual({
+				user: {
+					name: 'Alice',
+					email: 'alice@example.com',
+				},
+			});
+			expect(structured_content).toEqual({
+				user: {
+					name: 'Alice',
+					email: 'alice@example.com',
+				},
+			});
+		});
+
 		it('errors when text output contains non-text blocks', async () => {
 			const server = create_server();
 			server.tool(

--- a/packages/transport-cli/test/index.test.js
+++ b/packages/transport-cli/test/index.test.js
@@ -275,6 +275,39 @@ describe('CliTransport', () => {
 			);
 		});
 
+		it('warns for reserved command names and still allows calling the tool explicitly', async () => {
+			const server = create_server();
+
+			server.tool(
+				{ name: 'tools', description: 'Reserved-name tool' },
+				() => ({
+					content: [{ type: 'text', text: 'reserved' }],
+				}),
+			);
+
+			const list_cli = new CliTransport(server);
+			await list_cli.run(undefined, ['tools']);
+
+			expect(stderr_text()).toContain(
+				'Warning: skipping bare alias for tool "tools" because its name conflicts with a built-in command.',
+			);
+			const listed_tools = /** @type {Array<{ name: string }>} */ (
+				stdout_json()
+			);
+			expect(listed_tools.some((tool) => tool.name === 'tools')).toBe(
+				true,
+			);
+
+			stdout_chunks = [];
+			stderr_chunks = [];
+
+			const call_cli = new CliTransport(server);
+			await call_cli.run(undefined, ['call', 'tools']);
+
+			expect(stdout_json().content[0].text).toBe('reserved');
+			expect(stderr_text()).toContain('Use `call tools` instead.');
+		});
+
 		it('passes custom context to the server', async () => {
 			/** @type {{ userId: string } | undefined} */
 			let captured_ctx;

--- a/packages/transport-cli/test/index.test.js
+++ b/packages/transport-cli/test/index.test.js
@@ -1,0 +1,766 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { McpServer } from 'tmcp';
+import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
+import * as v from 'valibot';
+import { CliTransport } from '../src/index.js';
+
+const adapter = new ValibotJsonSchemaAdapter();
+
+const server_config = {
+	name: 'test-cli-server',
+	version: '1.0.0',
+	description: 'A test CLI server',
+};
+
+describe('CliTransport', () => {
+	/** @type {string[]} */
+	let stdout_chunks;
+
+	/** @type {string[]} */
+	let stderr_chunks;
+
+	beforeEach(() => {
+		stdout_chunks = [];
+		stderr_chunks = [];
+
+		vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+			stdout_chunks.push(String(chunk));
+			return true;
+		});
+
+		vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+			stderr_chunks.push(String(chunk));
+			return true;
+		});
+	});
+
+	describe('tool without arguments', () => {
+		it('should execute a tool with no input schema and print JSON result', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'ping',
+					description: 'Ping the server',
+				},
+				() => {
+					return {
+						content: [{ type: 'text', text: 'pong' }],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['ping']);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([{ type: 'text', text: 'pong' }]);
+		});
+	});
+
+	describe('tool with string arguments', () => {
+		it('should pass string arguments to the tool', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'greet',
+					description: 'Greet someone',
+					schema: v.object({
+						name: v.string(),
+					}),
+				},
+				(params) => {
+					return {
+						content: [
+							{ type: 'text', text: `Hello, ${params.name}!` },
+						],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['greet', '--name', 'Alice']);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([
+				{ type: 'text', text: 'Hello, Alice!' },
+			]);
+		});
+	});
+
+	describe('tool with number arguments', () => {
+		it('should parse and pass number arguments', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'add',
+					description: 'Add two numbers',
+					schema: v.object({
+						a: v.number(),
+						b: v.number(),
+					}),
+				},
+				(params) => {
+					return {
+						content: [
+							{
+								type: 'text',
+								text: `${params.a + params.b}`,
+							},
+						],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['add', '--a', '3', '--b', '4']);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([{ type: 'text', text: '7' }]);
+		});
+	});
+
+	describe('tool with boolean arguments', () => {
+		it('should parse and pass boolean arguments', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'toggle',
+					description: 'Toggle a flag',
+					schema: v.object({
+						verbose: v.boolean(),
+					}),
+				},
+				(params) => {
+					return {
+						content: [
+							{
+								type: 'text',
+								text: params.verbose ? 'verbose' : 'quiet',
+							},
+						],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['toggle', '--verbose']);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([{ type: 'text', text: 'verbose' }]);
+		});
+
+		it('should handle --no- prefix for boolean false', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'toggle',
+					description: 'Toggle a flag',
+					schema: v.object({
+						verbose: v.boolean(),
+					}),
+				},
+				(params) => {
+					return {
+						content: [
+							{
+								type: 'text',
+								text: params.verbose ? 'verbose' : 'quiet',
+							},
+						],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['toggle', '--no-verbose']);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([{ type: 'text', text: 'quiet' }]);
+		});
+
+		it('should handle kebab-case arguments', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'toggle',
+					description: 'Toggle a flag',
+					schema: v.object({
+						'kebab-case': v.boolean(),
+					}),
+				},
+				(params) => {
+					return {
+						content: [
+							{
+								type: 'text',
+								text: params['kebab-case']
+									? 'kebab-case'
+									: 'camelCase',
+							},
+						],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['toggle', '--kebab-case']);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([
+				{ type: 'text', text: 'kebab-case' },
+			]);
+		});
+	});
+
+	describe('tool with optional arguments', () => {
+		it('should handle optional arguments that are not provided', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'greet',
+					description: 'Greet someone',
+					schema: v.object({
+						name: v.string(),
+						greeting: v.optional(v.string()),
+					}),
+				},
+				(params) => {
+					const greeting = params.greeting ?? 'Hello';
+					return {
+						content: [
+							{
+								type: 'text',
+								text: `${greeting}, ${params.name}!`,
+							},
+						],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['greet', '--name', 'Bob']);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([
+				{ type: 'text', text: 'Hello, Bob!' },
+			]);
+		});
+
+		it('should pass optional arguments when provided', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'greet',
+					description: 'Greet someone',
+					schema: v.object({
+						name: v.string(),
+						greeting: v.optional(v.string()),
+					}),
+				},
+				(params) => {
+					const greeting = params.greeting ?? 'Hello';
+					return {
+						content: [
+							{
+								type: 'text',
+								text: `${greeting}, ${params.name}!`,
+							},
+						],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, [
+				'greet',
+				'--name',
+				'Bob',
+				'--greeting',
+				'Hi',
+			]);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([
+				{ type: 'text', text: 'Hi, Bob!' },
+			]);
+		});
+	});
+
+	describe('tool with enum arguments', () => {
+		it('should accept valid enum values', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'set_level',
+					description: 'Set log level',
+					schema: v.object({
+						level: v.picklist(['debug', 'info', 'warn', 'error']),
+					}),
+				},
+				(params) => {
+					return {
+						content: [
+							{
+								type: 'text',
+								text: `Level set to ${params.level}`,
+							},
+						],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['set_level', '--level', 'debug']);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([
+				{ type: 'text', text: 'Level set to debug' },
+			]);
+		});
+	});
+
+	describe('multiple tools', () => {
+		it('should register all tools as commands', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'tool_a',
+					description: 'Tool A',
+				},
+				() => ({
+					content: [{ type: 'text', text: 'A' }],
+				}),
+			);
+
+			server.tool(
+				{
+					name: 'tool_b',
+					description: 'Tool B',
+				},
+				() => ({
+					content: [{ type: 'text', text: 'B' }],
+				}),
+			);
+
+			// Call tool_a
+			const cli_a = new CliTransport(server);
+			await cli_a.run(undefined, ['tool_a']);
+
+			expect(stdout_chunks.length).toBe(1);
+			let result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([{ type: 'text', text: 'A' }]);
+
+			// Reset output
+			stdout_chunks = [];
+
+			// Call tool_b
+			const cli_b = new CliTransport(server);
+			await cli_b.run(undefined, ['tool_b']);
+
+			expect(stdout_chunks.length).toBe(1);
+			result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([{ type: 'text', text: 'B' }]);
+		});
+	});
+
+	describe('tool with mixed argument types', () => {
+		it('should handle a tool with string, number, and boolean arguments', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'create_user',
+					description: 'Create a user',
+					schema: v.object({
+						name: v.string(),
+						age: v.number(),
+						admin: v.optional(v.boolean()),
+					}),
+				},
+				(params) => {
+					return {
+						content: [
+							{
+								type: 'text',
+								text: JSON.stringify({
+									name: params.name,
+									age: params.age,
+									admin: params.admin ?? false,
+								}),
+							},
+						],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, [
+				'create_user',
+				'--name',
+				'Charlie',
+				'--age',
+				'30',
+				'--admin',
+			]);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			const parsed = JSON.parse(result.content[0].text);
+			expect(parsed).toEqual({
+				name: 'Charlie',
+				age: 30,
+				admin: true,
+			});
+		});
+	});
+
+	describe('tool execution error', () => {
+		it('should write errors to stderr and set exit code', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'failing_tool',
+					description: 'A tool that throws',
+				},
+				() => {
+					throw new Error('Something went wrong');
+				},
+			);
+
+			const cli = new CliTransport(server);
+
+			// Save and restore process.exitCode
+			const original_exit_code = process.exitCode;
+
+			await cli.run(undefined, ['failing_tool']);
+
+			// When a tool throws, the MCP server returns a JSON-RPC error,
+			// which the transport catches and writes to stderr
+			expect(stderr_chunks.length).toBeGreaterThan(0);
+			expect(stderr_chunks.join('')).toContain('Error:');
+			expect(process.exitCode).toBe(1);
+
+			process.exitCode = original_exit_code;
+		});
+	});
+
+	describe('output format', () => {
+		it('should output pretty-printed JSON', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'format_test',
+					description: 'Test output format',
+				},
+				() => ({
+					content: [{ type: 'text', text: 'test' }],
+				}),
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['format_test']);
+
+			expect(stdout_chunks.length).toBe(1);
+			// Verify it's pretty-printed (contains newlines and indentation)
+			expect(stdout_chunks[0]).toContain('\n');
+			expect(stdout_chunks[0]).toContain('  ');
+			// Verify it ends with a newline
+			expect(stdout_chunks[0].endsWith('\n')).toBe(true);
+			// Verify it's valid JSON
+			expect(() => JSON.parse(stdout_chunks[0])).not.toThrow();
+		});
+	});
+
+	describe('tool with array arguments', () => {
+		it('should parse array arguments', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'list_items',
+					description: 'List items',
+					schema: v.object({
+						items: v.array(v.string()),
+					}),
+				},
+				(params) => {
+					return {
+						content: [
+							{
+								type: 'text',
+								text: params.items.join(', '),
+							},
+						],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, [
+				'list_items',
+				'--items',
+				'foo',
+				'--items',
+				'bar',
+				'--items',
+				'baz',
+			]);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([
+				{ type: 'text', text: 'foo, bar, baz' },
+			]);
+		});
+	});
+
+	describe('custom context', () => {
+		it('should pass custom context to the server', async () => {
+			/** @type {{ userId: string } | undefined} */
+			let captured_ctx;
+
+			const server = /** @type {McpServer<any, { userId: string }>} */ (
+				new McpServer(server_config, {
+					adapter,
+					capabilities: { tools: {} },
+				})
+			);
+
+			server.tool(
+				{
+					name: 'ctx_tool',
+					description: 'Tool that reads context',
+				},
+				() => {
+					captured_ctx = server.ctx.custom;
+					return {
+						content: [
+							{
+								type: 'text',
+								text: `user: ${server.ctx.custom?.userId}`,
+							},
+						],
+					};
+				},
+			);
+
+			const cli = /** @type {CliTransport<{ userId: string }>} */ (
+				new CliTransport(server)
+			);
+
+			// Note: custom context is not passed through run() in this transport
+			// because the CLI doesn't have a way to inject it from argv.
+			// But we test that the run() method accepts it.
+			await cli.run({ userId: 'test-user' }, ['ctx_tool']);
+
+			expect(stdout_chunks.length).toBe(1);
+			expect(captured_ctx).toEqual({ userId: 'test-user' });
+		});
+	});
+
+	describe('tool with description in schema properties', () => {
+		it('should use property descriptions from schema', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'described_tool',
+					description: 'Tool with described args',
+					schema: v.object({
+						query: v.pipe(
+							v.string(),
+							v.description('The search query'),
+						),
+					}),
+				},
+				(params) => {
+					return {
+						content: [
+							{
+								type: 'text',
+								text: `Searching: ${params.query}`,
+							},
+						],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['described_tool', '--query', 'hello']);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([
+				{ type: 'text', text: 'Searching: hello' },
+			]);
+		});
+	});
+
+	describe('script name', () => {
+		it('should use the server name as the CLI script name', async () => {
+			const server = new McpServer(
+				{
+					name: 'my-custom-cli',
+					version: '1.0.0',
+					description: 'A custom CLI server',
+				},
+				{
+					adapter,
+					capabilities: { tools: {} },
+				},
+			);
+
+			server.tool(
+				{
+					name: 'noop',
+					description: 'Does nothing',
+				},
+				() => ({
+					content: [{ type: 'text', text: 'ok' }],
+				}),
+			);
+
+			const cli = new CliTransport(server);
+
+			/** @type {string[]} */
+			const log_chunks = [];
+
+			const exit_spy = vi
+				.spyOn(process, 'exit')
+				// @ts-expect-error -- mock needs to not actually exit
+				.mockImplementation(() => {});
+
+			const log_spy = vi
+				.spyOn(console, 'log')
+				.mockImplementation((...args) => {
+					log_chunks.push(args.join(' '));
+				});
+
+			const error_spy = vi
+				.spyOn(console, 'error')
+				.mockImplementation((...args) => {
+					log_chunks.push(args.join(' '));
+				});
+
+			try {
+				await cli.run(undefined, ['--help']);
+			} catch {
+				// yargs may throw after calling process.exit
+			}
+
+			const all_output =
+				log_chunks.join('\n') +
+				stdout_chunks.join('') +
+				stderr_chunks.join('');
+			expect(all_output).toContain('my-custom-cli');
+
+			exit_spy.mockRestore();
+			log_spy.mockRestore();
+			error_spy.mockRestore();
+		});
+	});
+
+	describe('tool with integer arguments', () => {
+		it('should handle integer schema types', async () => {
+			const server = new McpServer(server_config, {
+				adapter,
+				capabilities: { tools: {} },
+			});
+
+			server.tool(
+				{
+					name: 'count',
+					description: 'Count items',
+					schema: v.object({
+						n: v.pipe(v.number(), v.integer()),
+					}),
+				},
+				(params) => {
+					return {
+						content: [
+							{
+								type: 'text',
+								text: `Count: ${params.n}`,
+							},
+						],
+					};
+				},
+			);
+
+			const cli = new CliTransport(server);
+			await cli.run(undefined, ['count', '--n', '42']);
+
+			expect(stdout_chunks.length).toBe(1);
+			const result = JSON.parse(stdout_chunks[0]);
+			expect(result.content).toEqual([
+				{ type: 'text', text: 'Count: 42' },
+			]);
+		});
+	});
+});

--- a/packages/transport-cli/test/index.test.js
+++ b/packages/transport-cli/test/index.test.js
@@ -662,6 +662,95 @@ describe('CliTransport', () => {
 		});
 	});
 
+	describe('setup hook', () => {
+		it('invokes setup with the configured sade instance and runs custom commands', async () => {
+			const server = create_server();
+			server.tool({ name: 'noop', description: 'noop' }, () => ({
+				content: [{ type: 'text', text: 'noop' }],
+			}));
+
+			/** @type {unknown} */
+			let received_prog;
+			const action_spy = vi.fn((/** @type {string} */ name) => {
+				process.stdout.write(`Hello, ${name}!\n`);
+			});
+
+			const cli = new CliTransport(server, {
+				setup: (prog) => {
+					received_prog = prog;
+					prog.command('hello <name>', 'Say hi').action(action_spy);
+				},
+			});
+
+			await cli.run(undefined, ['hello', 'World']);
+
+			expect(received_prog).toBeDefined();
+			expect(typeof (/** @type {any} */ (received_prog).command)).toBe(
+				'function',
+			);
+			expect(action_spy).toHaveBeenCalledTimes(1);
+			expect(action_spy.mock.calls[0][0]).toBe('World');
+			expect(stdout_text()).toContain('Hello, World!');
+		});
+
+		it('awaits async custom command actions', async () => {
+			const server = create_server();
+			let completed = false;
+
+			const cli = new CliTransport(server, {
+				setup: (prog) => {
+					prog.command('ping', 'Ping').action(async () => {
+						await new Promise((resolve) => setTimeout(resolve, 5));
+						completed = true;
+						process.stdout.write('pong\n');
+					});
+				},
+			});
+
+			await cli.run(undefined, ['ping']);
+
+			expect(completed).toBe(true);
+			expect(stdout_text()).toContain('pong');
+		});
+
+		it('throws when a custom command reuses a built-in name', async () => {
+			const server = create_server();
+
+			const cli = new CliTransport(server, {
+				setup: (prog) => {
+					prog.command('tools', 'Override tools').action(() => {});
+				},
+			});
+
+			await cli.run(undefined, ['tools']);
+
+			expect(stderr_text()).toContain(
+				'Error: Command already exists: tools',
+			);
+			expect(process.exitCode).toBe(1);
+		});
+
+		it('throws when a custom command reuses a tool alias name', async () => {
+			const server = create_server();
+			server.tool({ name: 'greet', description: 'Greet' }, () => ({
+				content: [{ type: 'text', text: 'from tool' }],
+			}));
+
+			const cli = new CliTransport(server, {
+				setup: (prog) => {
+					prog.command('greet', 'Override greet').action(() => {});
+				},
+			});
+
+			await cli.run(undefined, ['greet']);
+
+			expect(stderr_text()).toContain(
+				'Error: Command already exists: greet',
+			);
+			expect(process.exitCode).toBe(1);
+		});
+	});
+
 	describe('help output', () => {
 		it('prints help when no command is provided', async () => {
 			const server = create_server({ name: 'my-custom-cli' });

--- a/packages/transport-cli/test/index.test.js
+++ b/packages/transport-cli/test/index.test.js
@@ -46,6 +46,10 @@ describe('CliTransport', () => {
 		original_exit_code = process.exitCode;
 		process.exitCode = undefined;
 
+		vi.spyOn(process, 'exit')
+			// @ts-expect-error test helper
+			.mockImplementation(() => undefined);
+
 		vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
 			stdout_chunks.push(String(chunk));
 			return true;
@@ -72,6 +76,12 @@ describe('CliTransport', () => {
 
 	function stdout_json() {
 		return JSON.parse(stdout_text());
+	}
+
+	function exit_spy() {
+		return /** @type {ReturnType<typeof vi.spyOn>} */ (
+			vi.mocked(process.exit)
+		);
 	}
 
 	describe('tools command', () => {
@@ -119,6 +129,7 @@ describe('CliTransport', () => {
 				'tools/list',
 				'tools/list',
 			]);
+			expect(exit_spy()).toHaveBeenCalledWith(0);
 		});
 	});
 
@@ -406,6 +417,7 @@ describe('CliTransport', () => {
 
 			expect(stderr_text()).toContain('Error:');
 			expect(process.exitCode).toBe(1);
+			expect(exit_spy()).toHaveBeenCalledWith(1);
 		});
 
 		it('writes tool-level isError responses to stderr', async () => {
@@ -651,6 +663,32 @@ describe('CliTransport', () => {
 	});
 
 	describe('help output', () => {
+		it('prints help when no command is provided', async () => {
+			const server = create_server({ name: 'my-custom-cli' });
+			server.tool({ name: 'noop', description: 'Does nothing' }, () => ({
+				content: [{ type: 'text', text: 'ok' }],
+			}));
+
+			const cli = new CliTransport(server);
+			exit_spy().mockClear();
+			const log_spy = vi
+				.spyOn(console, 'log')
+				.mockImplementation(() => {});
+
+			try {
+				await cli.run(undefined, []);
+			} catch {
+				// sade may throw after trying to exit.
+			}
+
+			expect(
+				stdout_text() +
+					stderr_text() +
+					log_spy.mock.calls.flat().join(' '),
+			).toContain('my-custom-cli');
+			log_spy.mockRestore();
+		});
+
 		it('uses the server name in help output', async () => {
 			const server = create_server({ name: 'my-custom-cli' });
 			server.tool({ name: 'noop', description: 'Does nothing' }, () => ({
@@ -658,10 +696,7 @@ describe('CliTransport', () => {
 			}));
 
 			const cli = new CliTransport(server);
-			const exit_spy = vi
-				.spyOn(process, 'exit')
-				// @ts-expect-error test helper
-				.mockImplementation(() => {});
+			exit_spy().mockClear();
 			const log_spy = vi
 				.spyOn(console, 'log')
 				.mockImplementation(() => {});
@@ -677,8 +712,6 @@ describe('CliTransport', () => {
 					stderr_text() +
 					log_spy.mock.calls.flat().join(' '),
 			).toContain('my-custom-cli');
-
-			exit_spy.mockRestore();
 			log_spy.mockRestore();
 		});
 	});

--- a/packages/transport-cli/tsconfig.json
+++ b/packages/transport-cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"allowJs": true,
+		"checkJs": true,
+		"declaration": true,
+		"emitDeclarationOnly": false,
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*", "test/**/*"],
+	"exclude": ["node_modules"]
+}

--- a/packages/transport-cli/tsconfig.json
+++ b/packages/transport-cli/tsconfig.json
@@ -9,7 +9,8 @@
 		"emitDeclarationOnly": false,
 		"strict": true,
 		"noEmit": true,
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"types": ["node"]
 	},
 	"include": ["src/**/*", "test/**/*"],
 	"exclude": ["node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,9 +407,9 @@ importers:
 
   packages/transport-cli:
     dependencies:
-      yargs:
-        specifier: ^17.7.2
-        version: 17.7.2
+      sade:
+        specifier: ^1.8.1
+        version: 1.8.1
     devDependencies:
       '@tmcp/adapter-valibot':
         specifier: workspace:^
@@ -417,9 +417,6 @@ importers:
       '@types/node':
         specifier: ^24.0.13
         version: 24.10.4
-      '@types/yargs':
-        specifier: ^17.0.33
-        version: 17.0.35
       dts-buddy:
         specifier: ^0.6.2
         version: 0.6.2(patch_hash=07f8be04259d076d0f945b74969e6db1b33e74f59bb6ab476216dbb7c8dcd68b)(typescript@5.9.3)
@@ -1966,12 +1963,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/yargs-parser@21.0.3':
-    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
-
-  '@types/yargs@17.0.35':
-    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
   '@typescript-eslint/types@8.49.0':
     resolution: {integrity: sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==}
@@ -5906,12 +5897,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/yargs-parser@21.0.3': {}
-
-  '@types/yargs@17.0.35':
-    dependencies:
-      '@types/yargs-parser': 21.0.3
 
   '@typescript-eslint/types@8.49.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,6 +405,37 @@ importers:
         specifier: ^4.0.0
         version: 4.0.15(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
 
+  packages/transport-cli:
+    dependencies:
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
+    devDependencies:
+      '@tmcp/adapter-valibot':
+        specifier: workspace:^
+        version: link:../adapter-valibot
+      '@types/node':
+        specifier: ^24.0.13
+        version: 24.10.4
+      '@types/yargs':
+        specifier: ^17.0.33
+        version: 17.0.35
+      dts-buddy:
+        specifier: ^0.6.2
+        version: 0.6.2(patch_hash=07f8be04259d076d0f945b74969e6db1b33e74f59bb6ab476216dbb7c8dcd68b)(typescript@5.9.3)
+      publint:
+        specifier: ^0.3.12
+        version: 0.3.16
+      tmcp:
+        specifier: workspace:^
+        version: link:../tmcp
+      valibot:
+        specifier: ^1.1.0
+        version: 1.2.0(typescript@5.9.3)
+      vitest:
+        specifier: ^4.0.6
+        version: 4.0.15(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+
   packages/transport-http:
     dependencies:
       '@tmcp/session-manager':
@@ -894,105 +925,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1646,67 +1661,56 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
@@ -1848,28 +1852,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1966,6 +1966,12 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
   '@typescript-eslint/types@8.49.0':
     resolution: {integrity: sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==}
@@ -3042,28 +3048,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -5904,6 +5906,12 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
 
   '@typescript-eslint/types@8.49.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       '@tmcp/adapter-valibot':
         specifier: workspace:^
         version: link:../../packages/adapter-valibot
+      '@tmcp/transport-cli':
+        specifier: workspace:^
+        version: link:../../packages/transport-cli
       '@tmcp/transport-stdio':
         specifier: workspace:^
         version: link:../../packages/transport-stdio


### PR DESCRIPTION
This is a brand new transport that allows you to convert your MCP server into a CLI!

It only converts tools because resources and prompts are to add context to an LLM and it doesn't really make sense (since the user can't run the CLI IN the input box)...one could argue we could copy to the clipboard but that's a bit unintuitive imho.

This obviously have a few limitations:

1. you can't use elicitation in your tools
2. you can't use sampling in your tools
3. you can't use roots

All of these are enforced by not providing the capability to the McpServer (so if you try to access it unconditionally it will throw) but I'd say is a good tradeoff.

Also for the moment the output is the whole returned object...wondering if instead should just be the content part of it.

EDIT: all greptile suggestions are valid, will fix tomorrow

EDIT EDIT: I'm an idiot...I remembered @43081j suggesting me yargs a replacement of commander but he suggested me sade and I probably picked up yargs from the wrong side of a module replacement 🤦🏻‍♂️ will migrate to sade tomorrow

Really curious to hear people opinion about this!

You can try out with `pnpm i @tmcp/transport-cli`

https://www.npmjs.com/package/@tmcp/transport-cli