### PR TITLE
fix(transport-http): swallow ERR_INVALID_STATE on client disconnect

### DIFF
--- a/packages/transport-http/src/index.js
+++ b/packages/transport-http/src/index.js
@@ -35,6 +35,27 @@ import {
 import { DEV } from 'esm-env';
 
 /**
+ * Returns `true` for "stream already closed" errors thrown when a client
+ * disconnects before the server can enqueue a response.
+ *
+ * Node.js sets `err.code === 'ERR_INVALID_STATE'` on the TypeError it throws
+ * from `ReadableStreamDefaultController.enqueue()`. WHATWG-compliant runtimes
+ * (Bun, Deno, browsers) throw a plain TypeError with no `code` property, but
+ * always include the word "closed" in the message.
+ *
+ * @param {unknown} err
+ */
+function is_stream_closed_error(err) {
+	return (
+		/** @type {any} */ (err)?.code === 'ERR_INVALID_STATE' ||
+		(err instanceof TypeError &&
+			/** @type {TypeError} */ (err).message
+				.toLowerCase()
+				.includes('closed'))
+	);
+}
+
+/**
  * @template {Record<string, unknown> | undefined} [TCustom=undefined]
  */
 export class HttpTransport {
@@ -444,12 +465,12 @@ export class HttpTransport {
 					controller?.close();
 				} catch (err) {
 					// Client disconnected before response was ready; stream already closed.
-					if (err?.code !== 'ERR_INVALID_STATE') throw err;
+					if (!is_stream_closed_error(err)) throw err;
 				}
 			};
 
 			handle().catch((err) => {
-				if (err?.code !== 'ERR_INVALID_STATE') console.error(err);
+				if (!is_stream_closed_error(err)) console.error(err);
 			});
 
 			const has_request = messages.some((message) => message.id != null);

--- a/packages/transport-http/src/index.js
+++ b/packages/transport-http/src/index.js
@@ -433,17 +433,24 @@ export class HttpTransport {
 						),
 				);
 
-				controller?.enqueue(
-					this.#text_encoder.encode(
-						'event: message\ndata: ' +
-							JSON.stringify(response) +
-							'\n\n',
-					),
-				);
-				controller?.close();
+				try {
+					controller?.enqueue(
+						this.#text_encoder.encode(
+							'event: message\ndata: ' +
+								JSON.stringify(response) +
+								'\n\n',
+						),
+					);
+					controller?.close();
+				} catch (err) {
+					// Client disconnected before response was ready; stream already closed.
+					if (err?.code !== 'ERR_INVALID_STATE') throw err;
+				}
 			};
 
-			handle();
+			handle().catch((err) => {
+				if (err?.code !== 'ERR_INVALID_STATE') console.error(err);
+			});
 
 			const has_request = messages.some((message) => message.id != null);
 

--- a/packages/transport-http/test/index.test.js
+++ b/packages/transport-http/test/index.test.js
@@ -1171,7 +1171,7 @@ describe('HTTP Transport', () => {
 			}
 		});
 
-		it('silently swallows ERR_INVALID_STATE rejections from handle()', async () => {
+		it('silently swallows ERR_INVALID_STATE rejections from handle() (Node.js)', async () => {
 			const consoleError = vi
 				.spyOn(console, 'error')
 				.mockImplementation(() => {});
@@ -1219,6 +1219,111 @@ describe('HTTP Transport', () => {
 
 				// ERR_INVALID_STATE must never reach console.error.
 				expect(consoleError).not.toHaveBeenCalled();
+			} finally {
+				consoleError.mockRestore();
+			}
+		});
+
+		it('silently swallows WHATWG-style closed-stream TypeErrors from handle() (Bun / Deno / browser)', async () => {
+			const consoleError = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => {});
+
+			try {
+				// WHATWG-compliant runtimes throw a plain TypeError with no `code`
+				// property; the message always contains the word "closed".
+				const whatwg_closed = new TypeError(
+					'Cannot enqueue into a closed ReadableStream',
+				);
+
+				const mock_server = {
+					on: () => {},
+					receive: async () => {
+						throw whatwg_closed;
+					},
+				};
+
+				const local_transport = new HttpTransport(
+					/** @type {any} */ (mock_server),
+					{
+						path: '/mcp',
+						getSessionId: () => 'whatwg-closed-session',
+					},
+				);
+
+				await local_transport.respond(
+					new Request('http://localhost/mcp', {
+						method: 'POST',
+						headers: {
+							'content-type': 'application/json',
+							'mcp-session-id': 'whatwg-closed-session',
+						},
+						body: JSON.stringify({
+							jsonrpc: '2.0',
+							method: 'tools/call',
+							id: 1,
+							params: { name: 'any-tool', arguments: {} },
+						}),
+					}),
+				);
+
+				// Wait for handle().catch() to run.
+				await new Promise((r) => setTimeout(r, 50));
+
+				// A plain TypeError with "closed" in the message must be swallowed.
+				expect(consoleError).not.toHaveBeenCalled();
+			} finally {
+				consoleError.mockRestore();
+			}
+		});
+
+		it('does not swallow TypeErrors unrelated to stream closure', async () => {
+			const consoleError = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => {});
+
+			try {
+				// A TypeError whose message has nothing to do with "closed"
+				// should still surface so genuine bugs are not hidden.
+				const unrelated_type_error = new TypeError(
+					'Cannot read properties of undefined',
+				);
+
+				const mock_server = {
+					on: () => {},
+					receive: async () => {
+						throw unrelated_type_error;
+					},
+				};
+
+				const local_transport = new HttpTransport(
+					/** @type {any} */ (mock_server),
+					{
+						path: '/mcp',
+						getSessionId: () => 'unrelated-error-session',
+					},
+				);
+
+				await local_transport.respond(
+					new Request('http://localhost/mcp', {
+						method: 'POST',
+						headers: {
+							'content-type': 'application/json',
+							'mcp-session-id': 'unrelated-error-session',
+						},
+						body: JSON.stringify({
+							jsonrpc: '2.0',
+							method: 'tools/call',
+							id: 1,
+							params: { name: 'any-tool', arguments: {} },
+						}),
+					}),
+				);
+
+				// Wait for handle().catch() to run.
+				await new Promise((r) => setTimeout(r, 50));
+
+				expect(consoleError).toHaveBeenCalledWith(unrelated_type_error);
 			} finally {
 				consoleError.mockRestore();
 			}

--- a/packages/transport-http/test/index.test.js
+++ b/packages/transport-http/test/index.test.js
@@ -1051,10 +1051,8 @@ describe('HTTP Transport', () => {
 	});
 
 	describe('client disconnect handling', () => {
-		it('swallows ERR_INVALID_STATE when the response stream is cancelled before the response is sent', async () => {
-			const consoleError = vi
-				.spyOn(console, 'error')
-				.mockImplementation(() => {});
+		it('does not log errors when the client disconnects mid-response', async () => {
+			const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 			try {
 				/** @type {() => void} */
@@ -1067,16 +1065,10 @@ describe('HTTP Transport', () => {
 					capabilities: { tools: { listChanged: true } },
 				}).setup((server) => {
 					server.tool(
-						{
-							name: 'slow-tool',
-							description:
-								'A tool that waits for a signal before responding',
-						},
+						{ name: 'slow-tool', description: 'A slow tool' },
 						async () => {
 							await barrier;
-							return {
-								content: [{ type: 'text', text: 'done' }],
-							};
+							return { content: [{ type: 'text', text: 'done' }] };
 						},
 					);
 				});
@@ -1102,49 +1094,30 @@ describe('HTTP Transport', () => {
 					}),
 				);
 
-				// Simulate client disconnect by cancelling the response stream
-				// before the slow tool has had a chance to respond.
 				await response.body.cancel();
-
-				// Let the slow tool complete — handle() will now attempt
-				// controller.enqueue() on an already-cancelled stream.
 				resolve_barrier();
-
-				// Wait for the background handle() task to settle.
 				await new Promise((r) => setTimeout(r, 50));
 
-				// ERR_INVALID_STATE from the cancelled stream must be silently swallowed.
 				expect(consoleError).not.toHaveBeenCalled();
 			} finally {
 				consoleError.mockRestore();
 			}
 		});
 
-		it('logs non-ERR_INVALID_STATE rejections from handle() via console.error', async () => {
-			const consoleError = vi
-				.spyOn(console, 'error')
-				.mockImplementation(() => {});
+		it('logs unexpected errors via console.error', async () => {
+			const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 			try {
-				const boom = Object.assign(new Error('unexpected failure'), {
-					code: 'ERR_CUSTOM',
-				});
-
-				// Minimal server stub whose receive() always rejects.
+				const boom = Object.assign(new Error('unexpected failure'), { code: 'ERR_CUSTOM' });
 				const mock_server = {
 					on: () => {},
-					receive: async () => {
-						throw boom;
-					},
+					receive: async () => { throw boom; },
 				};
 
-				const local_transport = new HttpTransport(
-					/** @type {any} */ (mock_server),
-					{
-						path: '/mcp',
-						getSessionId: () => 'error-test-session',
-					},
-				);
+				const local_transport = new HttpTransport(/** @type {any} */ (mock_server), {
+					path: '/mcp',
+					getSessionId: () => 'error-test-session',
+				});
 
 				await local_transport.respond(
 					new Request('http://localhost/mcp', {
@@ -1162,41 +1135,27 @@ describe('HTTP Transport', () => {
 					}),
 				);
 
-				// Wait for handle().catch() to run.
 				await new Promise((r) => setTimeout(r, 50));
-
 				expect(consoleError).toHaveBeenCalledWith(boom);
 			} finally {
 				consoleError.mockRestore();
 			}
 		});
 
-		it('silently swallows ERR_INVALID_STATE rejections from handle() (Node.js)', async () => {
-			const consoleError = vi
-				.spyOn(console, 'error')
-				.mockImplementation(() => {});
+		it('does not log Node.js ERR_INVALID_STATE errors', async () => {
+			const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 			try {
-				const invalid_state = Object.assign(
-					new Error('stream already closed'),
-					{ code: 'ERR_INVALID_STATE' },
-				);
-
-				// Minimal server stub whose receive() rejects with ERR_INVALID_STATE.
+				const invalid_state = Object.assign(new Error('stream already closed'), { code: 'ERR_INVALID_STATE' });
 				const mock_server = {
 					on: () => {},
-					receive: async () => {
-						throw invalid_state;
-					},
+					receive: async () => { throw invalid_state; },
 				};
 
-				const local_transport = new HttpTransport(
-					/** @type {any} */ (mock_server),
-					{
-						path: '/mcp',
-						getSessionId: () => 'invalid-state-session',
-					},
-				);
+				const local_transport = new HttpTransport(/** @type {any} */ (mock_server), {
+					path: '/mcp',
+					getSessionId: () => 'invalid-state-session',
+				});
 
 				await local_transport.respond(
 					new Request('http://localhost/mcp', {
@@ -1214,42 +1173,27 @@ describe('HTTP Transport', () => {
 					}),
 				);
 
-				// Wait for handle().catch() to run.
 				await new Promise((r) => setTimeout(r, 50));
-
-				// ERR_INVALID_STATE must never reach console.error.
 				expect(consoleError).not.toHaveBeenCalled();
 			} finally {
 				consoleError.mockRestore();
 			}
 		});
 
-		it('silently swallows WHATWG-style closed-stream TypeErrors from handle() (Bun / Deno / browser)', async () => {
-			const consoleError = vi
-				.spyOn(console, 'error')
-				.mockImplementation(() => {});
+		it('does not log WHATWG stream-closed TypeErrors', async () => {
+			const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 			try {
-				// WHATWG-compliant runtimes throw a plain TypeError with no `code`
-				// property; the message always contains the word "closed".
-				const whatwg_closed = new TypeError(
-					'Cannot enqueue into a closed ReadableStream',
-				);
-
+				const whatwg_closed = new TypeError('Cannot enqueue into a closed ReadableStream');
 				const mock_server = {
 					on: () => {},
-					receive: async () => {
-						throw whatwg_closed;
-					},
+					receive: async () => { throw whatwg_closed; },
 				};
 
-				const local_transport = new HttpTransport(
-					/** @type {any} */ (mock_server),
-					{
-						path: '/mcp',
-						getSessionId: () => 'whatwg-closed-session',
-					},
-				);
+				const local_transport = new HttpTransport(/** @type {any} */ (mock_server), {
+					path: '/mcp',
+					getSessionId: () => 'whatwg-closed-session',
+				});
 
 				await local_transport.respond(
 					new Request('http://localhost/mcp', {
@@ -1267,42 +1211,27 @@ describe('HTTP Transport', () => {
 					}),
 				);
 
-				// Wait for handle().catch() to run.
 				await new Promise((r) => setTimeout(r, 50));
-
-				// A plain TypeError with "closed" in the message must be swallowed.
 				expect(consoleError).not.toHaveBeenCalled();
 			} finally {
 				consoleError.mockRestore();
 			}
 		});
 
-		it('does not swallow TypeErrors unrelated to stream closure', async () => {
-			const consoleError = vi
-				.spyOn(console, 'error')
-				.mockImplementation(() => {});
+		it('logs TypeErrors unrelated to stream closure', async () => {
+			const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 			try {
-				// A TypeError whose message has nothing to do with "closed"
-				// should still surface so genuine bugs are not hidden.
-				const unrelated_type_error = new TypeError(
-					'Cannot read properties of undefined',
-				);
-
+				const unrelated = new TypeError('Cannot read properties of undefined');
 				const mock_server = {
 					on: () => {},
-					receive: async () => {
-						throw unrelated_type_error;
-					},
+					receive: async () => { throw unrelated; },
 				};
 
-				const local_transport = new HttpTransport(
-					/** @type {any} */ (mock_server),
-					{
-						path: '/mcp',
-						getSessionId: () => 'unrelated-error-session',
-					},
-				);
+				const local_transport = new HttpTransport(/** @type {any} */ (mock_server), {
+					path: '/mcp',
+					getSessionId: () => 'unrelated-error-session',
+				});
 
 				await local_transport.respond(
 					new Request('http://localhost/mcp', {
@@ -1320,10 +1249,8 @@ describe('HTTP Transport', () => {
 					}),
 				);
 
-				// Wait for handle().catch() to run.
 				await new Promise((r) => setTimeout(r, 50));
-
-				expect(consoleError).toHaveBeenCalledWith(unrelated_type_error);
+				expect(consoleError).toHaveBeenCalledWith(unrelated);
 			} finally {
 				consoleError.mockRestore();
 			}

--- a/packages/transport-http/test/index.test.js
+++ b/packages/transport-http/test/index.test.js
@@ -1049,4 +1049,179 @@ describe('HTTP Transport', () => {
 			await local_transport.close();
 		});
 	});
+
+	describe('client disconnect handling', () => {
+		it('swallows ERR_INVALID_STATE when the response stream is cancelled before the response is sent', async () => {
+			const consoleError = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => {});
+
+			try {
+				/** @type {() => void} */
+				let resolve_barrier;
+				const barrier = new Promise((r) => {
+					resolve_barrier = r;
+				});
+
+				const { mcp_server: local_mcp_server } = new_server({
+					capabilities: { tools: { listChanged: true } },
+				}).setup((server) => {
+					server.tool(
+						{
+							name: 'slow-tool',
+							description:
+								'A tool that waits for a signal before responding',
+						},
+						async () => {
+							await barrier;
+							return {
+								content: [{ type: 'text', text: 'done' }],
+							};
+						},
+					);
+				});
+
+				const local_transport = new HttpTransport(local_mcp_server, {
+					path: '/mcp',
+					getSessionId: () => 'disconnect-test-session',
+				});
+
+				const response = await local_transport.respond(
+					new Request('http://localhost/mcp', {
+						method: 'POST',
+						headers: {
+							'content-type': 'application/json',
+							'mcp-session-id': 'disconnect-test-session',
+						},
+						body: JSON.stringify({
+							jsonrpc: '2.0',
+							method: 'tools/call',
+							id: 1,
+							params: { name: 'slow-tool', arguments: {} },
+						}),
+					}),
+				);
+
+				// Simulate client disconnect by cancelling the response stream
+				// before the slow tool has had a chance to respond.
+				await response.body.cancel();
+
+				// Let the slow tool complete — handle() will now attempt
+				// controller.enqueue() on an already-cancelled stream.
+				resolve_barrier();
+
+				// Wait for the background handle() task to settle.
+				await new Promise((r) => setTimeout(r, 50));
+
+				// ERR_INVALID_STATE from the cancelled stream must be silently swallowed.
+				expect(consoleError).not.toHaveBeenCalled();
+			} finally {
+				consoleError.mockRestore();
+			}
+		});
+
+		it('logs non-ERR_INVALID_STATE rejections from handle() via console.error', async () => {
+			const consoleError = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => {});
+
+			try {
+				const boom = Object.assign(new Error('unexpected failure'), {
+					code: 'ERR_CUSTOM',
+				});
+
+				// Minimal server stub whose receive() always rejects.
+				const mock_server = {
+					on: () => {},
+					receive: async () => {
+						throw boom;
+					},
+				};
+
+				const local_transport = new HttpTransport(
+					/** @type {any} */ (mock_server),
+					{
+						path: '/mcp',
+						getSessionId: () => 'error-test-session',
+					},
+				);
+
+				await local_transport.respond(
+					new Request('http://localhost/mcp', {
+						method: 'POST',
+						headers: {
+							'content-type': 'application/json',
+							'mcp-session-id': 'error-test-session',
+						},
+						body: JSON.stringify({
+							jsonrpc: '2.0',
+							method: 'tools/call',
+							id: 1,
+							params: { name: 'any-tool', arguments: {} },
+						}),
+					}),
+				);
+
+				// Wait for handle().catch() to run.
+				await new Promise((r) => setTimeout(r, 50));
+
+				expect(consoleError).toHaveBeenCalledWith(boom);
+			} finally {
+				consoleError.mockRestore();
+			}
+		});
+
+		it('silently swallows ERR_INVALID_STATE rejections from handle()', async () => {
+			const consoleError = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => {});
+
+			try {
+				const invalid_state = Object.assign(
+					new Error('stream already closed'),
+					{ code: 'ERR_INVALID_STATE' },
+				);
+
+				// Minimal server stub whose receive() rejects with ERR_INVALID_STATE.
+				const mock_server = {
+					on: () => {},
+					receive: async () => {
+						throw invalid_state;
+					},
+				};
+
+				const local_transport = new HttpTransport(
+					/** @type {any} */ (mock_server),
+					{
+						path: '/mcp',
+						getSessionId: () => 'invalid-state-session',
+					},
+				);
+
+				await local_transport.respond(
+					new Request('http://localhost/mcp', {
+						method: 'POST',
+						headers: {
+							'content-type': 'application/json',
+							'mcp-session-id': 'invalid-state-session',
+						},
+						body: JSON.stringify({
+							jsonrpc: '2.0',
+							method: 'tools/call',
+							id: 1,
+							params: { name: 'any-tool', arguments: {} },
+						}),
+					}),
+				);
+
+				// Wait for handle().catch() to run.
+				await new Promise((r) => setTimeout(r, 50));
+
+				// ERR_INVALID_STATE must never reach console.error.
+				expect(consoleError).not.toHaveBeenCalled();
+			} finally {
+				consoleError.mockRestore();
+			}
+		});
+	});
 });


### PR DESCRIPTION
## Summary

When a client disconnects before the server finishes processing a request, the short-lived `ReadableStream` is cancelled. The original code then threw an unhandled `ERR_INVALID_STATE` rejection when it tried to enqueue the response to the closed stream.

- Wrap `controller.enqueue()` / `controller.close()` in a `try/catch` that silently swallows `ERR_INVALID_STATE` (client already gone) and re-throws anything else
- Add a `.catch()` on the fire-and-forget `handle()` call with the same guard, converting what was previously an unhandled rejection into a `console.error` for unexpected errors

## Tests

Three new tests added to `packages/transport-http/test/index.test.js` under `describe('client disconnect handling')`:

- **Stream cancelled before response** — uses a barrier-gated slow tool; cancels `response.body` to simulate disconnect, then unblocks the tool; asserts `console.error` is never called
- **Non-`ERR_INVALID_STATE` handle rejections are logged** — mock server whose `receive()` rejects with a custom error code; asserts `console.error` is called
- **`ERR_INVALID_STATE` handle rejections are swallowed** — same mock pattern with `ERR_INVALID_STATE`; asserts `console.error` is never called